### PR TITLE
Remove testing with elasticsearch 1.3 version.

### DIFF
--- a/Sanity/elasticsearch/elasticsearch.fmf
+++ b/Sanity/elasticsearch/elasticsearch.fmf
@@ -11,21 +11,6 @@ discover:
 execute:
   - how: tmt
 
-/v1.3.1:
-    adjust:
-      - enabled: false
-        when: distro >= rhel-9
-    prepare:
-      - how: shell
-        script:
-          - rpm -q elasticsearch || yum install -y https://github.com/RedHat-SP-Security/tests/wiki/sideload/elasticsearch-1.3.1.noarch.rpm
-          - systemctl daemon-reload
-          - sed -i 's/#ES_JAVA_OPTS=/ES_JAVA_OPTS=\"-Xss1024k\"/' /etc/sysconfig/elasticsearch
-    finish:
-      - how: shell
-        script:
-          - yum remove -y elasticsearch
-          - rm -rf /etc/elasticsearch /var/lib/elasticsearch
 /v7.3.0:
     adjust:
       - enabled: false


### PR DESCRIPTION
The service can not be started due to some java errors. This version has been released more than 10 years ago, thus let's drop it as it is quite old.
We test version `7.3.0` and the latest upstream version as well.