### PR TITLE
Fixed non-alphanumeric characters from naming of the test phases.

### DIFF
--- a/Multihost/EKU-purpose/main.fmf
+++ b/Multihost/EKU-purpose/main.fmf
@@ -13,8 +13,6 @@ tag+:
 - fedora-wanted
 - rhel-8.1
 - rhel-8.1.0
-- Tier3
-tier: 3
 extra-summary: /CoreOS/rsyslog/Multihost/EKU-purpose
 extra-nitrate: TC#0604425
 adjust:

--- a/Multihost/bz1614181-fromhost-property-case-sensitive-when-using-UDP/main.fmf
+++ b/Multihost/bz1614181-fromhost-property-case-sensitive-when-using-UDP/main.fmf
@@ -15,11 +15,8 @@ enabled: true
 tag+:
 - NoRHEL4
 - NoRHEL5
-- Tier2
-- Tier2security
 - fedora-wanted
 - rhel-8.1
-tier: '2'
 extra-summary: /CoreOS/rsyslog/Multihost/bz1614181-fromhost-property-case-sensitive-when-using-UDP
 extra-nitrate: TC#0600869
 adjust:

--- a/Multihost/rsyslog-gssapi-log-delivery-sanity/runtest.sh
+++ b/Multihost/rsyslog-gssapi-log-delivery-sanity/runtest.sh
@@ -126,7 +126,7 @@ EOF
         rlRun "syncSet SERVER_SETUP_READY"
     rlPhaseEnd
 
-    rlPhaseStartTest "$SERVER_SETUP_MESSAGE"
+    rlPhaseStartTest "Server message: $SERVER_SETUP_MESSAGE"
 	rlLogInfo "$CLIENT_SETUP_MESSAGE"
         # server setup goes here
 	rlRun "service rsyslog status" 0 "Verify that rsyslog is running"
@@ -241,7 +241,7 @@ EOF
     rlPhaseEnd
 
 
-   rlPhaseStartTest "$CLIENT_SETUP_MESSAGE"
+   rlPhaseStartTest "Client message: $CLIENT_SETUP_MESSAGE"
 	rlLogInfo "$SERVER_SETUP_MESSAGE"
         rlRun "syncSet CLIENT_TEST_READY"
         rlRun "syncExp SERVER_TEST_READY"

--- a/Regression/bz1223566-RFE-imrelp-does-not-support-binding-to-a-specific/runtest.sh
+++ b/Regression/bz1223566-RFE-imrelp-does-not-support-binding-to-a-specific/runtest.sh
@@ -51,7 +51,7 @@ rlJournalStart
         CleanupRegister 'rlRun "popd"'
     rlPhaseEnd
 
-    rsyslogConfigIsNewSyntax && rlPhaseStartTest "\"ruleset\" in module directive (Sanity)" && {
+    rsyslogConfigIsNewSyntax && rlPhaseStartTest "Testing: \"ruleset\" in module directive (Sanity)" && {
         rsyslogPrepareConf
         rsyslogConfigAppend --begin "MODULES" /etc/rsyslog.conf <<EOF
 module(load="imrelp" ruleset="relp")

--- a/Sanity/imrelp-omrelp-module-test/runtest.sh
+++ b/Sanity/imrelp-omrelp-module-test/runtest.sh
@@ -181,7 +181,7 @@ EOF
 
         for client_driver in "gnutls" "openssl"; do
             for server_driver in "gnutls" "openssl"; do
-                rlPhaseStartTest "$client_driver -> $server_driver" && tcfChk && {
+                rlPhaseStartTest "Testing: $client_driver -> $server_driver" && tcfChk && {
                     tcfChk "setup" && {
                         client_config $client_driver
                         server_config $server_driver

--- a/Sanity/imtcp-module-test/runtest.sh
+++ b/Sanity/imtcp-module-test/runtest.sh
@@ -139,7 +139,7 @@ EOF
 	rlAssertEquals "3 rsyslog instancies on IPv6 should be running" $IP6 3
     rlPhaseEnd; }
 
-    rlPhaseStartTest "\$InputTCPServerBindRuleset and TCP forwarding test" && {
+    rlPhaseStartTest "Testing: \$InputTCPServerBindRuleset and TCP forwarding test" && {
 	rlRun "logger -p local4.info 'test message 50514'" 0 "Sending test message1 for port 50514"
 	rlRun "logger -p local5.info 'test message 50515'" 0 "Sending test message2 for port 50515"
 	rlRun "logger -p local6.info 'test message 50516'" 0 "Sending test message3 for port 50516"

--- a/Sanity/mmfields-module-test/runtest.sh
+++ b/Sanity/mmfields-module-test/runtest.sh
@@ -52,7 +52,7 @@ EOF
   rlPhaseEnd; }
 
   while IFS='~' read -r title options message expected unexpected; do
-    rlPhaseStartTest "$title" && {
+    rlPhaseStartTest "Title: $title" && {
       rsyslogConfigReplace "RULES_MMFIELDS" <<EOF
         local2.* action(type="mmfields"${options:+" $options"})
         local2.* action(type="omfile" file="/var/log/rsyslog.test-cef.log" template="cef")

--- a/Sanity/omfile-module-test/runtest.sh
+++ b/Sanity/omfile-module-test/runtest.sh
@@ -44,7 +44,7 @@ rlJournalStart
     rlPhaseEnd
 
 if ! $VER3; then
-    rlPhaseStartTest "\$OMFileZipLevel test"   # logfile compression test"
+    rlPhaseStartTest "Testing: \$OMFileZipLevel test"   # logfile compression test"
         rsyslogConfigIsNewSyntax && rsyslogConfigAddTo --begin "RULES" /etc/rsyslog.conf < <(rsyslogConfigCreateSection ZIPTEST <<EOF
 # log file compression test
 local0.info    action(type="omfile" file="/var/log/rsyslog.test.gz" zipLevel="5")     # set logfile compression on
@@ -89,7 +89,7 @@ EOF
         rlRun "grep 'relpath test message' /tmp/rsyslog.rel-path-test.log" 0 "Check the message in the log"
     rlPhaseEnd
 
-    rlPhaseStartTest "\$OMFileFlushOnTXEnd and \$OMFileIOBufferSize test"  # check that messages are flushed in batch
+    rlPhaseStartTest "Testing: \$OMFileFlushOnTXEnd and \$OMFileIOBufferSize test"  # check that messages are flushed in batch
         rsyslogConfigReplace "RELPATH" /etc/rsyslog.conf
         rsyslogConfigIsNewSyntax && rsyslogConfigAppend --begin "RULES" /etc/rsyslog.conf < <(rsyslogConfigCreateSection FLUSHTEST <<EOF
 local0.info    action(type="omfile" file="/var/log/rsyslog.test.log" IOBufferSize="1k" FlushOnTXEnd="off")    # default is 4k

--- a/Sanity/test-various-configuration-directives/runtest.sh
+++ b/Sanity/test-various-configuration-directives/runtest.sh
@@ -50,7 +50,7 @@ rlJournalStart
         rsyslogConfigAddTo --begin "RULES" /etc/rsyslog.conf < <(rsyslogConfigCreateSection TESTBEGIN)
     rlPhaseEnd
 
-    rlPhaseStartTest "\$ActionExecOnlyOnceEveryInterval test" && {
+    rlPhaseStartTest "Action: \$ActionExecOnlyOnceEveryInterval test" && {
         rsyslogConfigIsNewSyntax || rsyslogConfigReplace "TEST1" <<EOF
 \$ActionExecOnlyOnceEveryInterval 3
 local0.info /var/log/rsyslog-ActionExecOnlyOnceEveryInterval-test.log
@@ -87,7 +87,7 @@ EOF
     rlPhaseEnd; }
 
   if rsyslogVersion '>=4.5.1'; then   # feature available since 4.5.1
-    rlPhaseStartTest "\$ActionSendTCPRebindInterval test, bz1645245" && {
+    rlPhaseStartTest "Action: \$ActionSendTCPRebindInterval test, bz1645245" && {
         rsyslogConfigIsNewSyntax || rsyslogConfigReplace "TEST1" /etc/rsyslog.conf <<EOF
 \$ModLoad imtcp.so
 \$ActionSendTCPRebindInterval 3
@@ -126,7 +126,7 @@ EOF
   fi
 
   if rsyslogVersion '>=5.8.10'; then   # feature available since 5.8.10
-    rlPhaseStartTest "\$PreserveFQDN test, related bz#805424" && {
+    rlPhaseStartTest "Action: \$PreserveFQDN test, related bz#805424" && {
       fqdn=$(hostname -f)
       short=$(hostname -s)
       rlRun "echo 'FQDN: $fqdn'"
@@ -169,7 +169,7 @@ EOF
   fi
 
   if rsyslogVersion '>=5.8.10'; then   # feature available probably since 5.8.10
-    rlPhaseStartTest "\$LocalHostName test" && {
+    rlPhaseStartTest "Action: \$LocalHostName test" && {
 	  NICKNAME=nickname.`hostname -d`
     if [[ ${#fqdn} -gt 64 ]]; then
       rlLog "Skipping test: FQDN length (${#fqdn}) is 64 or more characters."


### PR DESCRIPTION
Also remove multihost tests from tier testing.