### PR TITLE
Improved posixly-correct test based on RHEL versions

### DIFF
--- a/Regression/posixly-correct/runtest.sh
+++ b/Regression/posixly-correct/runtest.sh
@@ -31,9 +31,16 @@ rlJournalStart && {
     rlRun "rlCheckRecommended; rlCheckRequired" || rlDie "cannot continue"
   rlPhaseEnd; }
 
-  rlPhaseStartTest && {
-    rlAssertGrep 'systemctl -s HUP kill rsyslog' $(rpm -qal rsyslog\* | grep 'logrotate\.d')
-  rlPhaseEnd; }; :
+  if rlIsRHEL '<=9.6'; then
+    rlPhaseStartTest 
+      rlAssertGrep 'systemctl -s HUP kill rsyslog' $(rpm -qal rsyslog\* | grep 'logrotate\.d')
+    rlPhaseEnd;
 
+  elif rlIsRHEL '>=10.0'; then
+    rlPhaseStartTest
+      rlAssertGrep 'systemctl reload rsyslog.service' $(rpm -qal rsyslog\* | grep 'logrotate\.d')
+    rlPhaseEnd
+  fi
+  
   rlJournalPrintText
 rlJournalEnd; }

--- a/Regression/posixly-correct/runtest.sh
+++ b/Regression/posixly-correct/runtest.sh
@@ -31,16 +31,16 @@ rlJournalStart && {
     rlRun "rlCheckRecommended; rlCheckRequired" || rlDie "cannot continue"
   rlPhaseEnd; }
 
-  if rlIsRHEL '<=9.6'; then
+  if rlIsRHEL '<10'; then
     rlPhaseStartTest 
       rlAssertGrep 'systemctl -s HUP kill rsyslog' $(rpm -qal rsyslog\* | grep 'logrotate\.d')
     rlPhaseEnd;
 
-  elif rlIsRHEL '>=10.0'; then
+  elif rlIsRHEL '>=10'; then
     rlPhaseStartTest
       rlAssertGrep 'systemctl reload rsyslog.service' $(rpm -qal rsyslog\* | grep 'logrotate\.d')
     rlPhaseEnd
   fi
-  
+
   rlJournalPrintText
 rlJournalEnd; }


### PR DESCRIPTION
Fixed posixly-correct test based on different approach of restarting rsyslog.service based on RHEL version.

