### PR TITLE
New impstats-dropped-messages test

### DIFF
--- a/Sanity/impstats-dropped-messages/main.fmf
+++ b/Sanity/impstats-dropped-messages/main.fmf
@@ -1,0 +1,7 @@
+summary: Tests dropped messages of impstats module
+contact: Adam Prikryl <aprikryl@redhat.com>
+test: ./runtest.sh
+duration: 5m
+enabled: true
+require:
+  - rsyslog

--- a/Sanity/impstats-dropped-messages/main.fmf
+++ b/Sanity/impstats-dropped-messages/main.fmf
@@ -4,4 +4,11 @@ test: ./runtest.sh
 duration: 5m
 enabled: true
 require:
+  - url: https://github.com/RedHat-SP-Security/rsyslog-tests.git
+    name: /Library/basic
+    type: library
   - rsyslog
+tag:
+  - NoRHEL6
+  - Tier3
+tier: 3

--- a/Sanity/impstats-dropped-messages/runtest.sh
+++ b/Sanity/impstats-dropped-messages/runtest.sh
@@ -103,15 +103,6 @@ EOF
     rlPhaseEnd
 
     rlPhaseStartCleanup
-        rlLog "Performing final cleanup actions."
-        rlRun "rm -f \"$SOCKET\" \"$STATSFILE\" \"$LOGFILE\" \"$RSYSLOG_CONF\"" 0 "Removing temporary files"
-        # Kill the directly run rsyslogd if it's still running
-        if [ -f "$RSYSLOG_PIDFILE" ]; then
-            rlRun "kill \$(cat \"$RSYSLOG_PIDFILE\")" 0 "Killing custom rsyslogd"
-            rlRun "rm -f \"$RSYSLOG_PIDFILE\"" 0 "Removing PID file"
-        fi
-        rlFileRestore # This restores original /etc/rsyslog.conf
-        rlRun "systemctl daemon-reload" 0 "Reloading systemd daemons"
-        rlRun "rsyslogServiceStart"
+        CleanupDo
     rlPhaseEnd
 rlJournalEnd

--- a/Sanity/impstats-dropped-messages/runtest.sh
+++ b/Sanity/impstats-dropped-messages/runtest.sh
@@ -33,7 +33,7 @@
 PACKAGE="rsyslog"
 SOCKET="/tmp/rsyslog-test.sock"
 STATSFILE="/tmp/rsyslog.stats"
-RSYSLOG_CONF="/etc/rsyslog.conf" # Use the standard rsyslog.conf path if using rsyslog/basic library
+RSYSLOG_CONF="/etc/rsyslog.conf"
 LOGFILE="/tmp/rsyslog-test.log"
 RSYSLOG_PIDFILE="/tmp/rsyslog-test.pid"
 
@@ -42,7 +42,6 @@ rlJournalStart
         rlImport --all
         rlAssertRpm "$PACKAGE"
 
-        # Initial cleanup of test-specific files
         rlRun "rm -f \"$SOCKET\" \"$STATSFILE\" \"$LOGFILE\" \"$RSYSLOG_PIDFILE\"" 0 "Clean up any pre-existing test files"
 
         rlRun "rsyslogSetup" 0 "Initialize rsyslog test environment"
@@ -74,7 +73,7 @@ EOF
         rlRun "rsyslogPrintEffectiveConfig -n" 0 "Printing effective rsyslog config (grep non-commented lines)"
 
         rlRun "rsyslogd -N1 -f \"$RSYSLOG_CONF\" | tee /tmp/rsyslog-check.log" 0 "Validating rsyslog config"
-        rlAssertExists "/tmp/rsyslog-check.log" # Ensure the validation log exists
+        rlAssertExists "/tmp/rsyslog-check.log"
 
         rlRun "rsyslogd -n -f \"$RSYSLOG_CONF\" -i \"$RSYSLOG_PIDFILE\" &" 0 "Starting rsyslogd directly"
         RSYSLOGD_BG_PID=$!
@@ -113,6 +112,6 @@ EOF
         fi
         rlFileRestore # This restores original /etc/rsyslog.conf
         rlRun "systemctl daemon-reload" 0 "Reloading systemd daemons"
-        rlRun "systemctl start rsyslog || :" 0 "Starting system rsyslog (if it was active)"
+        rlRun "rsyslogServiceStart"
     rlPhaseEnd
 rlJournalEnd

--- a/Sanity/impstats-dropped-messages/runtest.sh
+++ b/Sanity/impstats-dropped-messages/runtest.sh
@@ -1,0 +1,111 @@
+# !/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   runtest.sh of /CoreOS/rsyslog/Sanity/impstats-dropped-messages
+#   Description: Smoke test for counter of discarded messages in impstats module
+#   Author: Adam Prikryl <aprikryl@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2025 Red Hat, Inc.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Include Beaker environment
+. /usr/bin/rhts-environment.sh || :
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+PACKAGE="rsyslog"
+SOCKET="/tmp/rsyslog-test.sock"
+STATSFILE="/tmp/rsyslog.stats"
+RSYSLOG_CONF="/etc/rsyslog.conf" # We are still replacing this for simplicity
+LOGFILE="/tmp/rsyslog-test.log"
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlAssertRpm "$PACKAGE"
+
+        rlRun "rm -f \"$SOCKET\" \"$STATSFILE\" \"$LOGFILE\" \"$RSYSLOG_PIDFILE\"" 0 "Clean up any pre-existing files"
+        rlRun "systemctl stop rsyslog" 0 "Stopping system rsyslog"
+        rlFileBackup "/etc/rsyslog.conf" # Backup the system's rsyslog.conf
+
+        rlRun "cat > \"$RSYSLOG_CONF\" << EOF
+# Minimal rsyslog configuration for this test
+module(load=\"imuxsock\")
+input(type=\"imuxsock\" Socket=\"$SOCKET\" CreatePath=\"on\"
+      RateLimit.Interval=\"1\" RateLimit.Burst=\"750\")
+
+module(load=\"impstats\" log.file=\"$STATSFILE\" interval=\"1\" ruleset=\"stats\" log.syslog=\"off\")
+
+template(name=\"outfmt\" type=\"string\" string=\"%msg%\\n\")
+
+ruleset(name=\"stats\") {
+    stop # Discard stats messages after processing by impstats
+}
+
+# Using property filter syntax for regex matching
+:msg, regex, \"msgnum:.*\" action(type=\"omfile\" file=\"$LOGFILE\" template=\"outfmt\")
+EOF" 0 "Writing custom rsyslog config"
+
+        rlRun "rsyslogd -N1 | tee /tmp/rsyslog-check.log" 0 "Validating rsyslog config"
+        # Ensure the log file exists before grepping, and quote pattern for grep
+        rlAssertExists "/tmp/rsyslog-check.log"
+
+        rlLog "Starting rsyslogd directly with custom config"
+        # Start rsyslogd in the background using our custom config
+        # -n: do not daemonize (run in foreground)
+        # -f: specify config file
+        # -i: specify PID file
+        rlRun "rsyslogd -n -f \"$RSYSLOG_CONF\" -i \"$RSYSLOG_PIDFILE\" &" 0 "Starting rsyslogd directly"
+        rlRun "sleep 2" 0 "Waiting for rsyslog to initialize"
+        rlAssertExists "$SOCKET"
+
+    rlPhaseEnd
+
+    rlPhaseStartTest
+        rlLog "Sending 1000 messages via imuxsock to trigger rate limiting"
+        rlRun "seq 1 1000 | sed 's/^/msgnum: /' | logger -d -u \"$SOCKET\"" 0 "Sending messages"
+
+        rlLog "Waiting for impstats to flush"
+        rlRun "sleep 5" # Increased sleep to ensure impstats has multiple intervals to flush
+
+        rlAssertExists "$STATSFILE"
+        rlLog "Contents of stats file:"
+        rlRun "cat \"$STATSFILE\""
+
+        rlLog "Verifying impstats includes 250 dropped (discarded) messages"
+        rlRun "grep -E -qs 'imuxsock:.*ratelimit\\.discarded=250' \"$STATSFILE\"" 0 "Checking for discarded message counter (exactly 250)"
+
+        rlLog "Checking that 750 messages were logged"
+        rlRun "wc -l < \"$LOGFILE\" | grep -q '^750$'" 0 "Checking log file line count (exactly 750)"
+
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlLog "Performing final cleanup actions."
+        rlRun "rm -f \"$SOCKET\" \"$STATSFILE\" \"$LOGFILE\"" 0 "Removing temporary files"
+        # Kill the directly run rsyslogd if it's still running
+        if [ -f "$RSYSLOG_PIDFILE" ]; then
+            rlRun "kill \$(cat \"$RSYSLOG_PIDFILE\")" 0 "Killing custom rsyslogd"
+            rlRun "rm -f \"$RSYSLOG_PIDFILE\"" 0 "Removing PID file"
+        fi
+        rlFileRestore # This restores original /etc/rsyslog.conf
+        rlRun "systemctl daemon-reload" 0 "Reloading systemd daemons"
+        rlRun "systemctl start rsyslog || :" 0 "Starting system rsyslog (if it was active)"
+    rlPhaseEnd
+rlJournalEnd

--- a/Sanity/impstats-dropped-messages/runtest.sh
+++ b/Sanity/impstats-dropped-messages/runtest.sh
@@ -67,8 +67,9 @@ EOF" 0 "Writing custom rsyslog config"
         # Ensure the log file exists before grepping, and quote pattern for grep
         rlAssertExists "/tmp/rsyslog-check.log"
 
-        rlLog "Starting rsyslogd directly with custom config"
         rlRun "rsyslogd -n -f \"$RSYSLOG_CONF\" -i \"$RSYSLOG_PIDFILE\" &" 0 "Starting rsyslogd directly"
+        RSYSLOGD_BG_PID=$!
+        rlLog "rsyslogd background PID: $RSYSLOGD_BG_PID"
         rlRun "sleep 2" 0 "Waiting for rsyslog to initialize"
         rlAssertExists "$SOCKET"
 

--- a/Sanity/impstats-dropped-messages/runtest.sh
+++ b/Sanity/impstats-dropped-messages/runtest.sh
@@ -33,7 +33,7 @@
 PACKAGE="rsyslog"
 SOCKET="/tmp/rsyslog-test.sock"
 STATSFILE="/tmp/rsyslog.stats"
-RSYSLOG_CONF="/tmp/rsyslog-test.conf" # We are still replacing this for simplicity
+RSYSLOG_CONF="/tmp/rsyslog-test.conf"
 LOGFILE="/tmp/rsyslog-test.log"
 RSYSLOG_PIDFILE="/tmp/rsyslog-test.pid"
 

--- a/Sanity/impstats-dropped-messages/runtest.sh
+++ b/Sanity/impstats-dropped-messages/runtest.sh
@@ -67,10 +67,6 @@ EOF" 0 "Writing custom rsyslog config"
         rlAssertExists "/tmp/rsyslog-check.log"
 
         rlLog "Starting rsyslogd directly with custom config"
-        # Start rsyslogd in the background using our custom config
-        # -n: do not daemonize (run in foreground)
-        # -f: specify config file
-        # -i: specify PID file
         rlRun "rsyslogd -n -f \"$RSYSLOG_CONF\" -i \"$RSYSLOG_PIDFILE\" &" 0 "Starting rsyslogd directly"
         rlRun "sleep 2" 0 "Waiting for rsyslog to initialize"
         rlAssertExists "$SOCKET"

--- a/Sanity/impstats-dropped-messages/runtest.sh
+++ b/Sanity/impstats-dropped-messages/runtest.sh
@@ -1,4 +1,4 @@
-# !/bin/bash
+#!/bin/bash
 # vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #


### PR DESCRIPTION
This test covers the new functionality of impstats module and rate-limiting dropped messages.

Goal - As a sysadmin, I would like rsyslog to provide visibility into the number of log messages dropped due to rate-limiting so that I can monitor and act upon this information to ensure no critical logs are missed.

## Summary by Sourcery

Tests:
- Introduce a smoke test script and FMF metadata to send 1000 messages via imuxsock and assert 250 are discarded and 750 are logged