### PR TITLE
Mv to recommend package

### DIFF
--- a/Library/basic/main.fmf
+++ b/Library/basic/main.fmf
@@ -2,8 +2,8 @@ summary: rsystlog testing library
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 require:
 - library(distribution/Log)
-- policycoreutils-python-utils
 - patch
 - openssl
 recommend:
 - rsyslog
+- policycoreutils-python-utils


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Relocate Library/basic/main.fmf to the recommend package directory