### PR TITLE
Sanity/gnutls-openssl | Wait for establishing TLS connection

### DIFF
--- a/Sanity/gnutls-openssl/runtest.sh
+++ b/Sanity/gnutls-openssl/runtest.sh
@@ -295,7 +295,7 @@ EOF
         # Wait for TLS connection to be established (up to 10 seconds)
         TLS_CONNECTED=0
         for i in {1..10}; do
-            if ss -tn | grep -q ':6514.*ESTAB'; then
+            if ss -tn | grep -q 'ESTAB.*:6514'; then
                 rlLog "TLS connection established after $i seconds"
                 TLS_CONNECTED=1
                 break
@@ -306,7 +306,7 @@ EOF
             rlRun "ss -tn state all '( dport = :6514 or sport = :6514 )'" 0 "Show all connections on port 6514 for debugging"
             rlFail "TLS connection to port 6514 was not established within 10 seconds"
         fi
-        rlRun "ss -tn | grep ':6514.*ESTAB'" 0 "Verify ESTABLISHED connection to port 6514 exists"
+        rlRun "ss -tn | grep 'ESTAB.*:6514'" 0 "Verify ESTABLISHED connection to port 6514 exists"
         rlRun "logger 'test message'"
         rlRun "sleep 3s"
         rlRun "cat $rsyslogServerLogDir/messages"
@@ -341,7 +341,7 @@ EOF
         # Wait for TLS connection to be established (up to 10 seconds)
         TLS_CONNECTED=0
         for i in {1..10}; do
-            if ss -tn | grep -q ':6514.*ESTAB'; then
+            if ss -tn | grep -q 'ESTAB.*:6514'; then
                 rlLog "TLS connection established after $i seconds"
                 TLS_CONNECTED=1
                 break
@@ -352,7 +352,7 @@ EOF
             rlRun "ss -tn state all '( dport = :6514 or sport = :6514 )'" 0 "Show all connections on port 6514 for debugging"
             rlFail "TLS connection to port 6514 was not established within 10 seconds"
         fi
-        rlRun "ss -tn | grep ':6514.*ESTAB'" 0 "Verify ESTABLISHED connection to port 6514 exists"
+        rlRun "ss -tn | grep 'ESTAB.*:6514'" 0 "Verify ESTABLISHED connection to port 6514 exists"
         rlRun "logger 'test message'"
         rlRun "sleep 3s"
         rlRun "cat $rsyslogServerLogDir/messages"
@@ -387,7 +387,7 @@ EOF
         # Wait for TLS connection to be established (up to 10 seconds)
         TLS_CONNECTED=0
         for i in {1..10}; do
-            if ss -tn | grep -q ':6514.*ESTAB'; then
+            if ss -tn | grep -q 'ESTAB.*:6514'; then
                 rlLog "TLS connection established after $i seconds"
                 TLS_CONNECTED=1
                 break
@@ -398,7 +398,7 @@ EOF
             rlRun "ss -tn state all '( dport = :6514 or sport = :6514 )'" 0 "Show all connections on port 6514 for debugging"
             rlFail "TLS connection to port 6514 was not established within 10 seconds"
         fi
-        rlRun "ss -tn | grep ':6514.*ESTAB'" 0 "Verify ESTABLISHED connection to port 6514 exists"
+        rlRun "ss -tn | grep 'ESTAB.*:6514'" 0 "Verify ESTABLISHED connection to port 6514 exists"
         rlRun "logger 'test message'"
         rlRun "sleep 3s"
         rlRun "cat $rsyslogServerLogDir/messages"
@@ -433,7 +433,7 @@ EOF
         # Wait for TLS connection to be established (up to 10 seconds)
         TLS_CONNECTED=0
         for i in {1..10}; do
-            if ss -tn | grep -q ':6514.*ESTAB'; then
+            if ss -tn | grep -q 'ESTAB.*:6514'; then
                 rlLog "TLS connection established after $i seconds"
                 TLS_CONNECTED=1
                 break
@@ -444,7 +444,7 @@ EOF
             rlRun "ss -tn state all '( dport = :6514 or sport = :6514 )'" 0 "Show all connections on port 6514 for debugging"
             rlFail "TLS connection to port 6514 was not established within 10 seconds"
         fi
-        rlRun "ss -tn | grep ':6514.*ESTAB'" 0 "Verify ESTABLISHED connection to port 6514 exists"
+        rlRun "ss -tn | grep 'ESTAB.*:6514'" 0 "Verify ESTABLISHED connection to port 6514 exists"
         rlRun "logger 'test message'"
         rlRun "sleep 3s"
         rlRun "cat $rsyslogServerLogDir/messages"

--- a/Sanity/gnutls-openssl/runtest.sh
+++ b/Sanity/gnutls-openssl/runtest.sh
@@ -292,6 +292,15 @@ EOF
         rlRun "tshark -i any -f 'tcp port 6514' -a 'filesize:100' -w wireshark.dump 2>tshark.stderr &" 0 "Running wireshark"
         TSHARK_PID=$!
         sleep 1
+        # Wait for TLS connection to be established (up to 10 seconds)
+        for i in {1..10}; do
+            if ss -tn | grep -q ':6514.*ESTAB'; then
+                rlLog "TLS connection established after $i seconds"
+                break
+            fi
+            sleep 1
+        done
+        rlRun "ss -tn | grep ':6514'" 0 "Verify connection to port 6514 exists"
         rlRun "logger 'test message'"
         rlRun "sleep 3s"
         rlRun "cat $rsyslogServerLogDir/messages"
@@ -323,6 +332,15 @@ EOF
         rlRun "tshark -i any -f 'tcp port 6514' -a 'filesize:100' -w wireshark.dump 2>tshark.stderr &" 0 "Running wireshark"
         TSHARK_PID=$!
         sleep 1
+        # Wait for TLS connection to be established (up to 10 seconds)
+        for i in {1..10}; do
+            if ss -tn | grep -q ':6514.*ESTAB'; then
+                rlLog "TLS connection established after $i seconds"
+                break
+            fi
+            sleep 1
+        done
+        rlRun "ss -tn | grep ':6514'" 0 "Verify connection to port 6514 exists"
         rlRun "logger 'test message'"
         rlRun "sleep 3s"
         rlRun "cat $rsyslogServerLogDir/messages"
@@ -354,6 +372,15 @@ EOF
         rlRun "tshark -i any -f 'tcp port 6514' -a 'filesize:100' -w wireshark.dump 2>tshark.stderr &" 0 "Running wireshark"
         TSHARK_PID=$!
         sleep 1
+        # Wait for TLS connection to be established (up to 10 seconds)
+        for i in {1..10}; do
+            if ss -tn | grep -q ':6514.*ESTAB'; then
+                rlLog "TLS connection established after $i seconds"
+                break
+            fi
+            sleep 1
+        done
+        rlRun "ss -tn | grep ':6514'" 0 "Verify connection to port 6514 exists"
         rlRun "logger 'test message'"
         rlRun "sleep 3s"
         rlRun "cat $rsyslogServerLogDir/messages"
@@ -385,6 +412,15 @@ EOF
         rlRun "tshark -i any -f 'tcp port 6514' -a 'filesize:100' -w wireshark.dump 2>tshark.stderr &" 0 "Running wireshark"
         TSHARK_PID=$!
         sleep 1
+        # Wait for TLS connection to be established (up to 10 seconds)
+        for i in {1..10}; do
+            if ss -tn | grep -q ':6514.*ESTAB'; then
+                rlLog "TLS connection established after $i seconds"
+                break
+            fi
+            sleep 1
+        done
+        rlRun "ss -tn | grep ':6514'" 0 "Verify connection to port 6514 exists"
         rlRun "logger 'test message'"
         rlRun "sleep 3s"
         rlRun "cat $rsyslogServerLogDir/messages"

--- a/Sanity/gnutls-openssl/runtest.sh
+++ b/Sanity/gnutls-openssl/runtest.sh
@@ -293,14 +293,20 @@ EOF
         TSHARK_PID=$!
         sleep 1
         # Wait for TLS connection to be established (up to 10 seconds)
+        TLS_CONNECTED=0
         for i in {1..10}; do
             if ss -tn | grep -q ':6514.*ESTAB'; then
                 rlLog "TLS connection established after $i seconds"
+                TLS_CONNECTED=1
                 break
             fi
             sleep 1
         done
-        rlRun "ss -tn | grep ':6514'" 0 "Verify connection to port 6514 exists"
+        if [[ $TLS_CONNECTED -eq 0 ]]; then
+            rlRun "ss -tn state all '( dport = :6514 or sport = :6514 )'" 0 "Show all connections on port 6514 for debugging"
+            rlFail "TLS connection to port 6514 was not established within 10 seconds"
+        fi
+        rlRun "ss -tn | grep ':6514.*ESTAB'" 0 "Verify ESTABLISHED connection to port 6514 exists"
         rlRun "logger 'test message'"
         rlRun "sleep 3s"
         rlRun "cat $rsyslogServerLogDir/messages"
@@ -333,14 +339,20 @@ EOF
         TSHARK_PID=$!
         sleep 1
         # Wait for TLS connection to be established (up to 10 seconds)
+        TLS_CONNECTED=0
         for i in {1..10}; do
             if ss -tn | grep -q ':6514.*ESTAB'; then
                 rlLog "TLS connection established after $i seconds"
+                TLS_CONNECTED=1
                 break
             fi
             sleep 1
         done
-        rlRun "ss -tn | grep ':6514'" 0 "Verify connection to port 6514 exists"
+        if [[ $TLS_CONNECTED -eq 0 ]]; then
+            rlRun "ss -tn state all '( dport = :6514 or sport = :6514 )'" 0 "Show all connections on port 6514 for debugging"
+            rlFail "TLS connection to port 6514 was not established within 10 seconds"
+        fi
+        rlRun "ss -tn | grep ':6514.*ESTAB'" 0 "Verify ESTABLISHED connection to port 6514 exists"
         rlRun "logger 'test message'"
         rlRun "sleep 3s"
         rlRun "cat $rsyslogServerLogDir/messages"
@@ -373,14 +385,20 @@ EOF
         TSHARK_PID=$!
         sleep 1
         # Wait for TLS connection to be established (up to 10 seconds)
+        TLS_CONNECTED=0
         for i in {1..10}; do
             if ss -tn | grep -q ':6514.*ESTAB'; then
                 rlLog "TLS connection established after $i seconds"
+                TLS_CONNECTED=1
                 break
             fi
             sleep 1
         done
-        rlRun "ss -tn | grep ':6514'" 0 "Verify connection to port 6514 exists"
+        if [[ $TLS_CONNECTED -eq 0 ]]; then
+            rlRun "ss -tn state all '( dport = :6514 or sport = :6514 )'" 0 "Show all connections on port 6514 for debugging"
+            rlFail "TLS connection to port 6514 was not established within 10 seconds"
+        fi
+        rlRun "ss -tn | grep ':6514.*ESTAB'" 0 "Verify ESTABLISHED connection to port 6514 exists"
         rlRun "logger 'test message'"
         rlRun "sleep 3s"
         rlRun "cat $rsyslogServerLogDir/messages"
@@ -413,14 +431,20 @@ EOF
         TSHARK_PID=$!
         sleep 1
         # Wait for TLS connection to be established (up to 10 seconds)
+        TLS_CONNECTED=0
         for i in {1..10}; do
             if ss -tn | grep -q ':6514.*ESTAB'; then
                 rlLog "TLS connection established after $i seconds"
+                TLS_CONNECTED=1
                 break
             fi
             sleep 1
         done
-        rlRun "ss -tn | grep ':6514'" 0 "Verify connection to port 6514 exists"
+        if [[ $TLS_CONNECTED -eq 0 ]]; then
+            rlRun "ss -tn state all '( dport = :6514 or sport = :6514 )'" 0 "Show all connections on port 6514 for debugging"
+            rlFail "TLS connection to port 6514 was not established within 10 seconds"
+        fi
+        rlRun "ss -tn | grep ':6514.*ESTAB'" 0 "Verify ESTABLISHED connection to port 6514 exists"
         rlRun "logger 'test message'"
         rlRun "sleep 3s"
         rlRun "cat $rsyslogServerLogDir/messages"


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Ensure TLS-based syslog sanity tests wait for the TCP connection on port 6514 to be established before proceeding, reducing flakiness due to timing issues.