### PR TITLE
Advisory testing 9.8/10.2 - Multihost test fixes

### DIFF
--- a/Multihost/EKU-purpose/main.fmf
+++ b/Multihost/EKU-purpose/main.fmf
@@ -4,6 +4,7 @@ test: ./runtest.sh
 require+:
   - rsyslog-gnutls
   - gnutls-utils
+  - library(ControlFlow/Cleanup)
 recommend:
   - rng-utils
   - rng-tools

--- a/Multihost/EKU-purpose/runtest.sh
+++ b/Multihost/EKU-purpose/runtest.sh
@@ -77,10 +77,13 @@ checkMessage() {
   }
   syncWaitForClient
   rlRun "sleep 3s"
-  rlRun -s "rsyslogCatLogFileFromPointer /var/log/messages"
   if syncIsClient; then
+    rlWaitForCmd "rsyslogCatLogFileFromPointer /var/log/messages | grep -q '$msg'" -t 30 -d 3
+    rlRun -s "rsyslogCatLogFileFromPointer /var/log/messages"
     rlAssertGrep "$msg" $rlRun_LOG
   else
+    rlRun "sleep 10s"
+    rlRun -s "rsyslogCatLogFileFromPointer /var/log/messages"
     if [[ -z "$neg" ]]; then
       rlAssertGrep "$msg" $rlRun_LOG
     else

--- a/Multihost/EKU-purpose/runtest.sh
+++ b/Multihost/EKU-purpose/runtest.sh
@@ -78,7 +78,7 @@ checkMessage() {
   syncWaitForClient
   rlRun "sleep 3s"
   if syncIsClient; then
-    rlWaitForCmd "rsyslogCatLogFileFromPointer /var/log/messages | grep -q '$msg'" -t 30 -d 3
+    rlWaitForCmd "rsyslogCatLogFileFromPointer /var/log/messages | grep -Fq \"$msg\"" -t 30 -d 3
     rlRun -s "rsyslogCatLogFileFromPointer /var/log/messages"
     rlAssertGrep "$msg" $rlRun_LOG
   else

--- a/Multihost/bz1326216-RFE-Include-remote-host-ip-in-some-tcp-server/runtest.sh
+++ b/Multihost/bz1326216-RFE-Include-remote-host-ip-in-some-tcp-server/runtest.sh
@@ -195,7 +195,12 @@ Client() {
         rlRun "syncExp CERTS_READY > certs.tar"
         rlRun "tar -xf certs.tar" 0 "Extract certificates"
 
-        rlRun "mkdir /etc/rsyslogd.d && chmod 700 /etc/rsyslogd.d" 0 "Create /etc/rsyslogd.d"
+        if [ -d "/etc/rsyslogd.d" ]; then
+            rlRun "rm -rf /etc/rsyslogd.d/*" 0 "Clear existing /etc/rsyslogd.d"
+        else
+            rlRun "mkdir -p /etc/rsyslogd.d" 0 "Create /etc/rsyslogd.d"
+        fi
+        rlRun "chmod 700 /etc/rsyslogd.d" 0 "Set permissions on /etc/rsyslogd.d"
         rlRun "mv *.pem /etc/rsyslogd.d/ && chmod 400 /etc/rsyslogd.d/* && restorecon -R /etc/rsyslogd.d" 0 "Move certificates to /etc/rsyslogd.d"
         rsyslogConfigIsNewSyntax || rsyslogConfigAppend "MODULES" /etc/rsyslog.conf <<EOF
 #\$LocalHostName $HOSTNAME

--- a/Multihost/bz1326216-RFE-Include-remote-host-ip-in-some-tcp-server/runtest.sh
+++ b/Multihost/bz1326216-RFE-Include-remote-host-ip-in-some-tcp-server/runtest.sh
@@ -194,14 +194,13 @@ Client() {
     rlPhaseStartSetup "Client setup"
         rlRun "syncExp CERTS_READY > certs.tar"
         rlRun "tar -xf certs.tar" 0 "Extract certificates"
-
         if [ -d "/etc/rsyslogd.d" ]; then
-            rlRun "rm -rf /etc/rsyslogd.d/*" 0 "Clear existing /etc/rsyslogd.d"
+            rlRun "rm -f /etc/rsyslogd.d/*.pem" 0 "Remove existing test certificates from /etc/rsyslogd.d"
         else
             rlRun "mkdir -p /etc/rsyslogd.d" 0 "Create /etc/rsyslogd.d"
         fi
         rlRun "chmod 700 /etc/rsyslogd.d" 0 "Set permissions on /etc/rsyslogd.d"
-        rlRun "mv *.pem /etc/rsyslogd.d/ && chmod 400 /etc/rsyslogd.d/* && restorecon -R /etc/rsyslogd.d" 0 "Move certificates to /etc/rsyslogd.d"
+        rlRun "mv *.pem /etc/rsyslogd.d/ && chmod 400 /etc/rsyslogd.d/*.pem && restorecon -R /etc/rsyslogd.d" 0 "Move certificates to /etc/rsyslogd.d"
         rsyslogConfigIsNewSyntax || rsyslogConfigAppend "MODULES" /etc/rsyslog.conf <<EOF
 #\$LocalHostName $HOSTNAME
 \$DefaultNetstreamDriver gtls

--- a/Multihost/bz701782-rsyslog-TLS-does-not-encrypt-traffic-on-s390x-and/runtest.sh
+++ b/Multihost/bz701782-rsyslog-TLS-does-not-encrypt-traffic-on-s390x-and/runtest.sh
@@ -139,7 +139,7 @@ y'"
       }
       rlRun "cat /root/.ssh/id*.pub >> /root/.ssh/authorized_keys"
       rlRun "cat /root/.ssh/id*.pub | syncSet SSH_KEY -"
-      rlRun "yum --enablerepo epel --enablerepo epel-internal install ansible-core -y"
+      rlRun "epel yum install ansible-core -y"
       rlRun "rlCheckRequirements ansible rhel-system-roles"
       cat > inventory.ini <<EOF
 [servers]

--- a/Multihost/bz726525-actionTryResume-never-resumes/runtest.sh
+++ b/Multihost/bz726525-actionTryResume-never-resumes/runtest.sh
@@ -70,7 +70,8 @@ rlJournalStart
         rlRun "pushd $TmpDir"
         CleanupRegister 'rlRun "rlFileRestore"; rlRun "rlServiceRestore systemd-journald"'
         rlRun "rlFileBackup --clean /var/log/bz701782-rsyslog.log /etc/systemd/journald.conf"
-        rlRun "sed -i 's/.*RateLimitInterval.*/RateLimitIntervalSec=1s/g; s/.*RateLimitBurst.*/RateLimitBurst=1000000/g' /etc/systemd/journald.conf"        rlRun "rlServiceStart systemd-journald"
+        rlRun "sed -i 's/.*RateLimitInterval.*/RateLimitIntervalSec=1s/g; s/.*RateLimitBurst.*/RateLimitBurst=1000000/g' /etc/systemd/journald.conf"
+        rlRun "rlServiceStart systemd-journald"
         rlRun "mkdir -p /var/lib/rsyslog && restorecon -v /var/lib/rsyslog"
         rlRun "rm -f /var/log/bz701782-rsyslog.log"
         rsyslogServerConfigAppend "RULES" << EOF

--- a/Multihost/bz726525-actionTryResume-never-resumes/runtest.sh
+++ b/Multihost/bz726525-actionTryResume-never-resumes/runtest.sh
@@ -85,6 +85,7 @@ local2.error action(
 	target="127.0.0.1" port="514" protocol="tcp"
 	queue.filename="remoteq"
 	queue.type="Disk"
+	queue.checkpointinterval="100"
 	action.resumeRetryCount="-1"
 	action.resumeInterval="5"
 	action.resumeIntervalMax="10"

--- a/Multihost/bz966974-Update-librelp-to-a-version-compatible-with/runtest.sh
+++ b/Multihost/bz966974-Update-librelp-to-a-version-compatible-with/runtest.sh
@@ -37,12 +37,17 @@
 Server() {
   rlPhaseStartSetup Server-setup && {
     tcfChk "Server setup phase" && {
-      cat >rsyslog.conf.add <<EOF
-#module(load="imrelp")
-#input(type="imrelp" port="2514")
+      if rsyslogConfigIsNewSyntax; then
+        cat >rsyslog.conf.add <<EOF
+module(load="imrelp")
+input(type="imrelp" port="2514")
+EOF
+      else
+        cat >rsyslog.conf.add <<EOF
 \$ModLoad imrelp
 \$InputRELPServerRun 2514
 EOF
+      fi
       rlRun "cat rsyslog.conf.add | tee -a /etc/rsyslog.conf"
       rlRun "rlServiceStop rsyslog"
       rlRun "cat /var/log/messages > messages"
@@ -70,12 +75,17 @@ rlPhaseStartTest Server && {
 Client() {
   rlPhaseStartSetup Client-setup && {
     tcfChk "Client setup phase" && {
-      cat >rsyslog.conf.add <<EOF
-#module(load="omrelp")
-#action(type="omrelp" target="$syncSERVER" port="2514")
+      if rsyslogConfigIsNewSyntax; then
+        cat >rsyslog.conf.add <<EOF
+module(load="omrelp")
+*.* action(type="omrelp" target="$syncSERVER" port="2514")
+EOF
+      else
+        cat >rsyslog.conf.add <<EOF
 \$ModLoad omrelp
 *.* :omrelp:$syncSERVER:2514
 EOF
+      fi
       rlRun "cat rsyslog.conf.add | tee -a /etc/rsyslog.conf"
       rlRun "rlServiceStart rsyslog"
       rlRun "syncExp SERVER_SETUP_READY"

--- a/Multihost/bz966974-Update-librelp-to-a-version-compatible-with/runtest.sh
+++ b/Multihost/bz966974-Update-librelp-to-a-version-compatible-with/runtest.sh
@@ -87,15 +87,16 @@ EOF
 EOF
       fi
       rlRun "cat rsyslog.conf.add | tee -a /etc/rsyslog.conf"
+      rlRun "syncExp SERVER_SETUP_READY"
       rlRun "rlServiceStop rsyslog"
       rlRun "rlServiceStart rsyslog"
-      rlRun "syncExp SERVER_SETUP_READY"
     tcfFin; }
   rlPhaseEnd; }
 
   rlPhaseStartTest Client && {
     tcfChk "Client phase" && {
       rlRun "logger 'relptest'"
+      rlRun "sleep 3" 0 "Wait for rsyslog to forward the message via RELP"
       rlRun "syncSet CLIENT_DONE"
     tcfFin; }
   rlPhaseEnd; }

--- a/Multihost/bz966974-Update-librelp-to-a-version-compatible-with/runtest.sh
+++ b/Multihost/bz966974-Update-librelp-to-a-version-compatible-with/runtest.sh
@@ -87,6 +87,7 @@ EOF
 EOF
       fi
       rlRun "cat rsyslog.conf.add | tee -a /etc/rsyslog.conf"
+      rlRun "rlServiceStop rsyslog"
       rlRun "rlServiceStart rsyslog"
       rlRun "syncExp SERVER_SETUP_READY"
     tcfFin; }

--- a/Multihost/relp/main.fmf
+++ b/Multihost/relp/main.fmf
@@ -3,6 +3,7 @@ test: ./runtest.sh
 require+:
 - library(ControlFlow/Cleanup)
 - library(rpm/snapshot)
+- library(distribution/dpcommon)
 - rsyslog
 - rsyslog-relp
 - gnutls

--- a/Multihost/relp/runtest.sh
+++ b/Multihost/relp/runtest.sh
@@ -307,7 +307,7 @@ Client() {
         rlRun "syncExp CERTS_READY > certs.tar"
         rlRun "tar -xf certs.tar" 0 "Extract certificates"
 
-        rlRun "mkdir /etc/rsyslogd.d && chmod 700 /etc/rsyslogd.d" 0 "Create /etc/rsyslogd.d"
+        rlRun "mkdir -p /etc/rsyslogd.d && chmod 700 /etc/rsyslogd.d" 0 "Create /etc/rsyslogd.d"
         rlRun "mv *.pem /etc/rsyslogd.d/ && chmod 400 /etc/rsyslogd.d/* && restorecon -R /etc/rsyslogd.d" 0 "Move certificates to /etc/rsyslogd.d"
         rsyslogConfigIsNewSyntax || rsyslogConfigAppend "MODULES" /etc/rsyslog.conf <<EOF
 EOF

--- a/Multihost/rsyslog-send-messages-to-remote/runtest.sh
+++ b/Multihost/rsyslog-send-messages-to-remote/runtest.sh
@@ -256,6 +256,7 @@ EOF
   else
     syncIsServer && rlPhaseStartSetup "Server setup" && {
       # rsyslog setup
+      mkdir -p /etc/rsyslog.d
       cat > /etc/rsyslog.d/test.conf <<EOF
 \$ModLoad imtcp.so
 \$InputTCPServerRun 514
@@ -268,6 +269,7 @@ EOF
     syncIsClient && rlPhaseStartSetup "Client setup" && {
       # rsyslog setup
       rlRun "mkdir -p /var/spool/rsyslog && restorecon -v /var/spool/rsyslog"
+      mkdir -p /etc/rsyslog.d
       cat > /etc/rsyslog.d/test.conf <<EOF
 local2.error    @@$syncOTHER_IP
 EOF


### PR DESCRIPTION
## Summary by Sourcery

Improve robustness and reliability of multihost rsyslog test scenarios.

Bug Fixes:
- Ensure rsyslog certificate directory setup handles pre-existing /etc/rsyslogd.d content safely in TLS-related multihost tests.
- Increase synchronization and log-waiting logic in EKU-purpose tests to reduce flakiness when verifying expected log messages.
- Fix ansible-core installation in s390x TLS multihost test by using the epel wrapper for yum with appropriate repos.
- Ensure rsyslog configuration directories exist on client and server in remote logging multihost tests to prevent configuration write failures.
- Adjust rsyslog disk queue configuration in actionTryResume test to use a finite checkpoint interval, improving resume behavior under load.

Enhancements:
- Standardize creation and permission setting of /etc/rsyslogd.d with mkdir -p across relevant multihost tests.
- Add missing metadata files (main.fmf) for EKU-purpose and relp multihost tests.