### PR TITLE
Fix TLS test timing failures on aarch64

### DIFF
--- a/Regression/bz1880434-gnutls-shutdown/runtest.sh
+++ b/Regression/bz1880434-gnutls-shutdown/runtest.sh
@@ -160,7 +160,7 @@ EOF
   tcfTry "Tests" --no-assert && {
     rlPhaseStartTest && {
       rlRun "logger 'test message'"
-      rlRun "sleep 3s"
+      rlRun "rlWaitForCmd 'grep -q \"test message\" $rsyslogServerLogDir/messages' -t 60 -d 1" 0 "Wait for message to arrive"
       rlAssertGrep 'test message' $rsyslogServerLogDir/messages
       rlRun "iptables -I INPUT 1 -p tcp --dport 6514 -j DROP"
       rlRun "iptables -vnL INPUT"

--- a/Sanity/bz1932795-rebase-to-2102/runtest.sh
+++ b/Sanity/bz1932795-rebase-to-2102/runtest.sh
@@ -496,12 +496,13 @@ EOF
     rlPhaseStartTest "tls driver: certificate verify depth(max depth:3, actual depth:3)" && {
         client_config gtls 3
         server_config gtls 3
+        rlRun "rm -f /var/log/rsyslog-stats.log"
 
         rlRun "rsyslogServerStart"
         rlRun "rsyslogServiceStart"
         rlRun "sleep 1"
         rlRun "logger -p local6.info 'TLS driver: certificate chain depth'"
-        rlRun "sleep 3"
+        rlRun "rlWaitForCmd 'grep -q \"TLS driver: certificate chain depth\" /var/log/rsyslog-stats.log' -t 60 -d 1" 0 "Wait for message to arrive"
         rlRun "rsyslogServerStatus"
         rlRun -s "rsyslogServiceStatus"
         rlRun "cat /var/log/rsyslog-stats.log"


### PR DESCRIPTION
## Summary
- Replace fixed `sleep` delays with `rlWaitForCmd` polling in two TLS tests that intermittently fail on aarch64 due to slower TLS handshake + message delivery
- **bz1932795** (depth 3,3 test): `sleep 3` -> `rlWaitForCmd` with 60s timeout; also add `rm -f` for the log file before the test to prevent false positives from stale data left by the preceding depth 2,3 test
- **bz1880434** (gnutls-shutdown): `sleep 3s` -> `rlWaitForCmd` with 60s timeout

Testing farm results: https://artifacts.osci.redhat.com/testing-farm/48c765aa-95af-4e47-8fa5-91dbbcffef99/

rebase MR: https://gitlab.com/redhat/centos-stream/rpms/rsyslog/-/merge_requests/54 