### PR TITLE
Add fips tag to FIPS-relevant tests

### DIFF
--- a/Sanity/imtcp-module-test/main.fmf
+++ b/Sanity/imtcp-module-test/main.fmf
@@ -33,3 +33,5 @@ recommend:
 duration: 10m
 enabled: true
 extra-task: /CoreOS/rsyslog/Sanity/imtcp-module-test
+tag:
+  - fips


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Mark imtcp module sanity tests as FIPS-related so they can be selected or filtered in FIPS test runs.