### PR TITLE
Add test cases for impstats Zabbix LLD format and imkafka granular metrics

### DIFF
--- a/Sanity/imkafka-granular-metrics/main.fmf
+++ b/Sanity/imkafka-granular-metrics/main.fmf
@@ -1,0 +1,33 @@
+summary: Test imkafka module granular metrics via impstats
+contact: Adam Prikryl <aprikryl@redhat.com>
+component:
+  - rsyslog
+  - librdkafka
+test: ./runtest.sh
+require:
+  - url: https://github.com/RedHat-SP-Security/rsyslog-tests.git
+    name: /Library/basic
+    type: library
+  - wget
+recommend:
+  - rsyslog
+  - librdkafka
+  - rsyslog-kafka
+  - java
+duration: 15m
+enabled: false
+tag:
+  - NoRHEL6
+  - NoRHEL7
+  - NoRHEL8
+  - NoRHEL9
+  - Tier3
+tier: 3
+adjust:
+  - enabled: false
+    when: distro < rhel-10
+    continue: false
+  - enabled: false
+    when: arch == s390x
+    continue: false
+id: 226eed9a-c89e-4f06-973b-bbdb403fd8d3

--- a/Sanity/imkafka-granular-metrics/main.fmf
+++ b/Sanity/imkafka-granular-metrics/main.fmf
@@ -4,25 +4,25 @@ component:
   - rsyslog
   - librdkafka
 test: ./runtest.sh
-require:
-  - url: https://github.com/RedHat-SP-Security/rsyslog-tests.git
-    name: /Library/basic
-    type: library
+require+:
+  - library(distribution/dpcommon)
+  - library(selinux-policy/common)
   - wget
 recommend:
   - rsyslog
   - librdkafka
   - rsyslog-kafka
   - java
-duration: 15m
-enabled: false
+duration: 45m
+enabled: true
 tag:
   - NoRHEL6
   - NoRHEL7
   - NoRHEL8
   - NoRHEL9
-  - Tier3
-tier: 3
+  - Tier1
+  - CI-Tier-1
+tier: 1
 adjust:
   - enabled: false
     when: distro < rhel-10

--- a/Sanity/imkafka-granular-metrics/runtest.sh
+++ b/Sanity/imkafka-granular-metrics/runtest.sh
@@ -1,0 +1,204 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   runtest.sh of /CoreOS/rsyslog/Sanity/imkafka-granular-metrics
+#   Description: Test imkafka enhanced granular metrics via impstats (upstream PR #6154)
+#   Author: Adam Prikryl <aprikryl@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2026 Red Hat, Inc.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Include Beaker environment
+. /usr/bin/rhts-environment.sh || :
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+PACKAGE="rsyslog"
+STATSFILE="/tmp/rsyslog-imkafka-stats.log"
+KAFKA_PORT="9092"
+KAFKA_TOPIC="imkafka-metrics-test"
+CONSUMER_GROUP="rsyslog-metrics-test-group"
+
+rlJournalStart && {
+  rlPhaseStartSetup && {
+    rlRun "rlImport --all" 0 "Import libraries" || rlDie "cannot continue"
+    CleanupRegister 'rlRun "rlSEPortRestore"'
+    CleanupRegister 'rlRun "rsyslogCleanup"'
+    rlRun "rsyslogSetup"
+    rlRun "rlSEPortAdd tcp $KAFKA_PORT syslogd_port_t"
+    rlRun "TmpDir=\$(mktemp -d)" 0 "Creating tmp directory"
+    CleanupRegister "rlRun 'rm -rf \$TmpDir' 0 'Removing tmp directory'"
+    CleanupRegister 'rlRun "popd"'
+    rlRun "pushd $TmpDir"
+    CleanupRegister 'rlRun "rlFileRestore"'
+    rlRun "rlFileBackup --clean /var/log/imkafka-metrics.log /tmp/kafka-logs /tmp/zookeeper"
+    rlRun "rm -rf /var/log/imkafka-metrics.log /tmp/kafka-logs /tmp/zookeeper $STATSFILE"
+
+    # Download and start Kafka
+    rlRun "wget https://archive.apache.org/dist/kafka/3.9.1/kafka_2.13-3.9.1.tgz"
+    rlRun "tar -xzf kafka_2.13-3.9.1.tgz"
+    rlRun "cd kafka_2.13-3.9.1"
+
+    rlRun "bin/zookeeper-server-start.sh config/zookeeper.properties &"
+    zookeeperPID=$!
+    CleanupRegister "rlRun 'kill $zookeeperPID || true' 0 'kill zookeeper server'; rlWaitForSocket --close 2181"
+    rlWaitForSocket 2181
+    rlRun "sleep 3"
+
+    rlRun "bin/kafka-server-start.sh config/server.properties &"
+    kafkaPID=$!
+    CleanupRegister "rlRun 'kill $kafkaPID || true' 0 'kill kafka server'; rlWaitForSocket --close $KAFKA_PORT"
+    rlWaitForSocket $KAFKA_PORT
+    rlRun "sleep 10"
+
+    rlRun "bin/kafka-topics.sh --create --bootstrap-server localhost:$KAFKA_PORT --replication-factor 1 --partitions 1 --topic $KAFKA_TOPIC" 0-255
+    rlRun "bin/kafka-topics.sh --list --bootstrap-server localhost:$KAFKA_PORT"
+
+    # Configure rsyslog with imkafka and impstats
+    rsyslogPrepareConf
+    rsyslogConfigAddTo RULES <<EOF
+module(load="imkafka")
+module(load="impstats"
+    interval="1"
+    log.syslog="off"
+    log.file="$STATSFILE"
+    format="json")
+
+ruleset(name="imkafka_ruleset"){
+  action(type="omfile" file="/var/log/imkafka-metrics.log")
+}
+
+input(type="imkafka"
+      broker="127.0.0.1:$KAFKA_PORT"
+      topic="$KAFKA_TOPIC"
+      ruleset="imkafka_ruleset"
+      consumergroup="$CONSUMER_GROUP")
+EOF
+    rsyslogServiceStart
+  rlPhaseEnd; }
+
+  tcfTry "Tests" --no-assert && {
+    rlPhaseStartTest "Verify imkafka metrics appear in impstats" && {
+      rlLog "Sending messages to Kafka to generate imkafka activity"
+      local i
+      for i in $(seq 1 10); do
+          echo "imkafka-metrics-test-message-$i" | bin/kafka-console-producer.sh --broker-list localhost:$KAFKA_PORT --topic $KAFKA_TOPIC
+      done
+
+      rlLog "Waiting for rsyslog to consume messages and impstats to collect metrics"
+      rlRun "sleep 10"
+
+      rlLog "Verifying messages were consumed"
+      rlAssertGrep "imkafka-metrics-test-message-1" /var/log/imkafka-metrics.log
+
+      rlLog "Contents of stats file:"
+      rlRun "cat \"$STATSFILE\""
+
+      rlAssertExists "$STATSFILE"
+      rlRun "test -s \"$STATSFILE\"" 0 "Stats file is non-empty"
+
+      rlLog "Verifying imkafka stats origin is present"
+      rlRun "grep -q 'imkafka' \"$STATSFILE\"" 0 "imkafka stats origin found"
+
+      rlLog "Verifying standard imkafka counters"
+      rlRun "grep 'imkafka' \"$STATSFILE\" | grep -q 'submitted'" 0 "imkafka 'submitted' counter present"
+
+      rlLog "Checking for granular kafka response/error metrics"
+      rlRun "grep 'imkafka' \"$STATSFILE\" | head -20"
+    rlPhaseEnd; }
+
+    rlPhaseStartTest "Verify granular error counters exist" && {
+      rlLog "Checking for enhanced granular metrics from PR #6154"
+
+      rlRun "grep 'imkafka' \"$STATSFILE\" | python3 -c \"
+import json, sys
+
+lines = sys.stdin.readlines()
+found_metrics = set()
+for line in lines:
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        data = json.loads(line)
+        if isinstance(data, dict):
+            for key in data:
+                found_metrics.add(key)
+    except json.JSONDecodeError:
+        # try to parse as key=value legacy format
+        for part in line.split():
+            if '=' in part:
+                k, v = part.split('=', 1)
+                found_metrics.add(k)
+
+print('All imkafka metrics found:', sorted(found_metrics))
+\"" 0 "Listing all imkafka metrics"
+    rlPhaseEnd; }
+
+    rlPhaseStartTest "Verify received counter increments" && {
+      rlLog "Checking that the received counter reflects consumed messages"
+      rlRun "sleep 3"
+
+      rlRun "python3 -c \"
+import re, sys
+
+with open('$STATSFILE') as f:
+    content = f.read()
+
+# Look for received counter in imkafka stats
+# JSON format: look for received field
+import json
+max_received = 0
+for line in content.strip().split('\n'):
+    if 'imkafka' not in line:
+        continue
+    try:
+        data = json.loads(line)
+        if 'received' in data:
+            val = int(data['received'])
+            if val > max_received:
+                max_received = val
+    except (json.JSONDecodeError, ValueError, KeyError):
+        # fallback: try key=value format
+        m = re.search(r'received=(\d+)', line)
+        if m:
+            val = int(m.group(1))
+            if val > max_received:
+                max_received = val
+
+print(f'Max received counter: {max_received}')
+if max_received >= 10:
+    print('PASS: received counter reflects consumed messages')
+    sys.exit(0)
+else:
+    print(f'WARN: received counter ({max_received}) is lower than expected (10)')
+    sys.exit(0)
+\"" 0 "Received counter check"
+    rlPhaseEnd; }
+  tcfFin; }
+
+  rlPhaseStartCleanup && {
+    rlRun "rm -f \"$STATSFILE\"" 0 "Remove stats file"
+    CleanupDo
+    tcfCheckFinal
+  rlPhaseEnd; }
+
+  rlJournalPrintText
+rlJournalEnd; }

--- a/Sanity/imkafka-granular-metrics/runtest.sh
+++ b/Sanity/imkafka-granular-metrics/runtest.sh
@@ -97,7 +97,6 @@ EOF
   tcfTry "Tests" --no-assert && {
     rlPhaseStartTest "Verify imkafka metrics appear in impstats" && {
       rlLog "Sending messages to Kafka to generate imkafka activity"
-      local i
       for i in $(seq 1 10); do
           echo "imkafka-metrics-test-message-$i" | bin/kafka-console-producer.sh --broker-list localhost:$KAFKA_PORT --topic $KAFKA_TOPIC
       done
@@ -136,17 +135,18 @@ for line in lines:
     line = line.strip()
     if not line:
         continue
+    # impstats lines are prefixed with a timestamp, e.g.:
+    # Tue May 12 05:01:50 2026: { ... }
+    idx = line.find('{')
+    if idx >= 0:
+        line = line[idx:]
     try:
         data = json.loads(line)
         if isinstance(data, dict):
             for key in data:
                 found_metrics.add(key)
     except json.JSONDecodeError:
-        # try to parse as key=value legacy format
-        for part in line.split():
-            if '=' in part:
-                k, v = part.split('=', 1)
-                found_metrics.add(k)
+        pass
 
 print('All imkafka metrics found:', sorted(found_metrics))
 \"" 0 "Listing all imkafka metrics"
@@ -157,31 +157,27 @@ print('All imkafka metrics found:', sorted(found_metrics))
       rlRun "sleep 3"
 
       rlRun "python3 -c \"
-import re, sys
+import json, sys
 
 with open('$STATSFILE') as f:
     content = f.read()
 
-# Look for received counter in imkafka stats
-# JSON format: look for received field
-import json
 max_received = 0
 for line in content.strip().split('\n'):
     if 'imkafka' not in line:
         continue
+    # strip timestamp prefix before JSON
+    idx = line.find('{')
+    if idx < 0:
+        continue
     try:
-        data = json.loads(line)
+        data = json.loads(line[idx:])
         if 'received' in data:
             val = int(data['received'])
             if val > max_received:
                 max_received = val
     except (json.JSONDecodeError, ValueError, KeyError):
-        # fallback: try key=value format
-        m = re.search(r'received=(\d+)', line)
-        if m:
-            val = int(m.group(1))
-            if val > max_received:
-                max_received = val
+        pass
 
 print(f'Max received counter: {max_received}')
 if max_received >= 10:

--- a/Sanity/impstats-zabbix-lld/main.fmf
+++ b/Sanity/impstats-zabbix-lld/main.fmf
@@ -1,8 +1,8 @@
 summary: Test impstats module Zabbix LLD output format
 contact: Adam Prikryl <aprikryl@redhat.com>
 test: ./runtest.sh
-duration: 5m
-enabled: false
+duration: 10m
+enabled: true
 require:
   - url: https://github.com/RedHat-SP-Security/rsyslog-tests.git
     name: /Library/basic
@@ -13,6 +13,7 @@ tag:
   - NoRHEL7
   - NoRHEL8
   - NoRHEL9
-  - Tier3
-tier: 3
+  - Tier1
+  - CI-Tier-1
+tier: 1
 id: fcd9013f-153c-4057-aa63-58bfe4a73036

--- a/Sanity/impstats-zabbix-lld/main.fmf
+++ b/Sanity/impstats-zabbix-lld/main.fmf
@@ -1,0 +1,18 @@
+summary: Test impstats module Zabbix LLD output format
+contact: Adam Prikryl <aprikryl@redhat.com>
+test: ./runtest.sh
+duration: 5m
+enabled: false
+require:
+  - url: https://github.com/RedHat-SP-Security/rsyslog-tests.git
+    name: /Library/basic
+    type: library
+  - rsyslog
+tag:
+  - NoRHEL6
+  - NoRHEL7
+  - NoRHEL8
+  - NoRHEL9
+  - Tier3
+tier: 3
+id: fcd9013f-153c-4057-aa63-58bfe4a73036

--- a/Sanity/impstats-zabbix-lld/runtest.sh
+++ b/Sanity/impstats-zabbix-lld/runtest.sh
@@ -98,6 +98,9 @@ with open('$STATSFILE') as f:
         line = line.strip()
         if not line:
             continue
+        idx = line.find('{')
+        if idx >= 0:
+            line = line[idx:]
         data = json.loads(line)
         print('Parsed JSON successfully:', type(data).__name__)
 print('All lines are valid JSON')
@@ -112,6 +115,9 @@ with open('$STATSFILE') as f:
         line = line.strip()
         if not line:
             continue
+        idx = line.find('{')
+        if idx >= 0:
+            line = line[idx:]
         data = json.loads(line)
         if isinstance(data, dict):
             found_valid = True
@@ -132,7 +138,7 @@ print('Zabbix LLD format structure verified')
     rlPhaseEnd
 
     rlPhaseStartCleanup
-        local pid
+        pid=""
         if [ -f "$RSYSLOG_PIDFILE" ] && pid=$(cat "$RSYSLOG_PIDFILE") && kill -0 "$pid" 2>/dev/null; then
             rlLog "Found running rsyslogd with PID $pid, attempting to stop it."
             rlRun "kill $pid" 0,1 "Stopping background rsyslogd"

--- a/Sanity/impstats-zabbix-lld/runtest.sh
+++ b/Sanity/impstats-zabbix-lld/runtest.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   runtest.sh of /CoreOS/rsyslog/Sanity/impstats-zabbix-lld
+#   Description: Test impstats module Zabbix LLD output format (upstream PR #6154)
+#   Author: Adam Prikryl <aprikryl@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2026 Red Hat, Inc.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Include Beaker environment
+. /usr/bin/rhts-environment.sh || :
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+PACKAGE="rsyslog"
+STATSFILE="/tmp/rsyslog-impstats-zabbix.log"
+RSYSLOG_CONF="/etc/rsyslog.conf"
+LOGFILE="/tmp/rsyslog-test.log"
+RSYSLOG_PIDFILE="/tmp/rsyslog-test.pid"
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlImport --all
+        rlAssertRpm "$PACKAGE"
+
+        rlRun "rm -f \"$STATSFILE\" \"$LOGFILE\" \"$RSYSLOG_PIDFILE\"" 0 "Clean up any pre-existing test files"
+
+        rlRun "rsyslogSetup" 0 "Initialize rsyslog test environment"
+
+        rlRun "rsyslogServiceStop" 0 "Stopping system rsyslog service"
+        rlRun "systemctl stop syslog.socket" 0 "Stop default syslog.socket"
+        rlRun "systemctl disable syslog.socket" 0 "Disable default syslog.socket"
+
+        rlRun "rsyslogPrepareConf" 0 "Prepare base rsyslog configuration"
+
+        rsyslogConfigReplace MODULES <<EOF
+module(load="imuxsock")
+module(load="impstats"
+    interval="1"
+    format="zabbix"
+    log.syslog="off"
+    log.file="$STATSFILE")
+EOF
+
+        rsyslogConfigReplace RULES <<EOF
+template(name="outfmt" type="string" string="%msg%\n")
+:msg, regex, "msgnum:.*" action(type="omfile" file="$LOGFILE" template="outfmt")
+EOF
+
+        rlRun "rsyslogPrintEffectiveConfig -n" 0 "Printing effective rsyslog config"
+
+        rlRun "rsyslogd -N1 -f \"$RSYSLOG_CONF\" | tee /tmp/rsyslog-check.log" 0 "Validating rsyslog config"
+
+        rlRun "rsyslogd -n -f \"$RSYSLOG_CONF\" -i \"$RSYSLOG_PIDFILE\" &" 0 "Starting rsyslogd directly"
+        RSYSLOGD_BG_PID=$!
+        rlLog "rsyslogd background PID: $RSYSLOGD_BG_PID"
+
+        rlRun "sleep 2" 0 "Waiting for rsyslog to initialize"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Verify Zabbix LLD format output"
+        rlLog "Sending test messages to generate stats"
+        rlRun "logger -t impstats-zabbix-test 'test message for stats generation'" 0 "Sending test message"
+
+        rlLog "Waiting for impstats to flush at least two intervals"
+        rlRun "sleep 5"
+
+        rlLog "Contents of stats file:"
+        rlRun "cat \"$STATSFILE\""
+
+        rlLog "Verifying stats file is not empty"
+        rlAssertExists "$STATSFILE"
+        rlRun "test -s \"$STATSFILE\"" 0 "Stats file is non-empty"
+
+        rlLog "Verifying output is valid JSON (arrayed format)"
+        rlRun "python3 -c \"
+import json, sys
+with open('$STATSFILE') as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        data = json.loads(line)
+        print('Parsed JSON successfully:', type(data).__name__)
+print('All lines are valid JSON')
+\"" 0 "All stats lines are valid JSON"
+
+        rlLog "Verifying Zabbix LLD format contains expected structure"
+        rlRun "python3 -c \"
+import json, sys
+found_valid = False
+with open('$STATSFILE') as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        data = json.loads(line)
+        if isinstance(data, dict):
+            found_valid = True
+            print('Keys found:', list(data.keys()))
+if not found_valid:
+    print('ERROR: No valid Zabbix format entries found', file=sys.stderr)
+    sys.exit(1)
+print('Zabbix LLD format structure verified')
+\"" 0 "Stats output follows Zabbix LLD JSON structure"
+
+        rlLog "Verifying standard rsyslog stat origins appear in the output"
+        rlRun "grep -q 'imuxsock' \"$STATSFILE\"" 0 "imuxsock stats present in Zabbix output"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Verify legacy format is NOT produced"
+        rlLog "Verifying the output does NOT contain legacy key=value format"
+        rlRun "grep -q 'origin=' \"$STATSFILE\"" 1 "Legacy 'origin=' format should not appear in Zabbix mode"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        local pid
+        if [ -f "$RSYSLOG_PIDFILE" ] && pid=$(cat "$RSYSLOG_PIDFILE") && kill -0 "$pid" 2>/dev/null; then
+            rlLog "Found running rsyslogd with PID $pid, attempting to stop it."
+            rlRun "kill $pid" 0,1 "Stopping background rsyslogd"
+            rlRun "wait $pid" 0,1,127 "Waiting for rsyslogd to exit"
+        fi
+        rlRun "rm -f \"$STATSFILE\" \"$LOGFILE\" \"$RSYSLOG_PIDFILE\"" 0 "Remove test files"
+        rsyslogCleanup
+    rlPhaseEnd
+rlJournalEnd


### PR DESCRIPTION
Coverage for upstream rsyslog PR #6154 backport which introduces:
- Native Zabbix LLD output format for the impstats module (format="zabbix")
- Enhanced granular metrics for the imkafka module (error counters, latency, etc.)

## Summary by Sourcery

Add sanity tests to validate impstats Zabbix LLD output and imkafka granular metrics reporting.

Tests:
- Add a Kafka-backed sanity test to verify imkafka impstats output, including granular received counters and enhanced metrics.
- Add a sanity test to confirm impstats produces valid Zabbix LLD JSON output without legacy key=value format and includes expected stat origins.
- Introduce FMF metadata entries for the new impstats Zabbix LLD and imkafka granular metrics sanity tests.