### PR TITLE
Fix omprog-HUP test failure in systemctl phase

### DIFF
--- a/Sanity/omprog/signal_HUP/runtest.sh
+++ b/Sanity/omprog/signal_HUP/runtest.sh
@@ -60,6 +60,8 @@ input(type="imuxsock" Socket="/dev/log2")
 EOF
     cat > /usr/libexec/rsyslog/log_rotate.sh << 'EOF'
 #!/bin/bash
+# ignore SIGHUP - systemctl kill sends the signal to all processes in the cgroup
+trap '' HUP
 exec >> /var/log/logs/test.out
 exec 2>&1
 file=/var/log/logs/test.log


### PR DESCRIPTION
The "send signal using systemctl" phase fails because `systemctl --signal=HUP kill rsyslog` sends SIGHUP to all processes in the rsyslog cgroup, including the log_rotate.sh script itself (launched by omprog). The script gets killed before writing "after SIGHUP". Add `trap '' HUP` so the script ignores the cgroup-wide signal.

## Summary by Sourcery

Bug Fixes:
- Ignore SIGHUP in the log_rotate.sh helper script to avoid premature termination when systemd sends HUP to the entire rsyslog cgroup during tests.