### PR TITLE
Add missing descriptions to main.fmf test cases

### DIFF
--- a/Multihost/EKU-purpose/main.fmf
+++ b/Multihost/EKU-purpose/main.fmf
@@ -1,4 +1,5 @@
 summary: Test for extended key usage purpose
+description: Verify that rsyslog GnuTLS streaming correctly validates Extended Key Usage (EKU) purpose in TLS certificates, accepting connections with correct EKU or no EKU and rejecting connections with wrong EKU when CheckExtendedKeyPurpose is enabled on both server and client sides.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 require+:

--- a/Multihost/EKU-purpose/main.fmf
+++ b/Multihost/EKU-purpose/main.fmf
@@ -1,5 +1,9 @@
 summary: Test for extended key usage purpose
-description: Verify that rsyslog GnuTLS streaming correctly validates Extended Key Usage (EKU) purpose in TLS certificates, accepting connections with correct EKU or no EKU and rejecting connections with wrong EKU when CheckExtendedKeyPurpose is enabled on both server and client sides.
+description: |
+    Verify that rsyslog GnuTLS streaming correctly validates Extended Key
+    Usage (EKU) purpose in TLS certificates, accepting connections with
+    correct EKU or no EKU and rejecting connections with wrong EKU when
+    CheckExtendedKeyPurpose is enabled on both server and client sides.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 require+:

--- a/Multihost/ipv6-sanity-test/main.fmf
+++ b/Multihost/ipv6-sanity-test/main.fmf
@@ -1,5 +1,5 @@
 summary: basic ipv6 sanity testing
-description: ''
+description: Verify that rsyslog correctly sends and receives log messages over IPv6 using both UDP and TCP protocols, and that messages sent via IPv4 are not received when the server is configured to listen on IPv6 only.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 component:
   - rsyslog7

--- a/Multihost/ipv6-sanity-test/main.fmf
+++ b/Multihost/ipv6-sanity-test/main.fmf
@@ -1,5 +1,8 @@
 summary: basic ipv6 sanity testing
-description: Verify that rsyslog correctly sends and receives log messages over IPv6 using both UDP and TCP protocols, and that messages sent via IPv4 are not received when the server is configured to listen on IPv6 only.
+description: |
+    Verify that rsyslog correctly sends and receives log messages over IPv6
+    using both UDP and TCP protocols, and that messages sent via IPv4 are
+    not received when the server is configured to listen on IPv6 only.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 component:
   - rsyslog7

--- a/Multihost/relp/main.fmf
+++ b/Multihost/relp/main.fmf
@@ -1,3 +1,5 @@
+summary: Test rsyslog RELP transport with TLS encryption
+description: Verify that rsyslog reliably delivers messages between client and server using RELP with GnuTLS encryption, confirming all 500 test messages arrive without loss or duplication and that traffic is encrypted on the wire.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 require+:

--- a/Multihost/relp/main.fmf
+++ b/Multihost/relp/main.fmf
@@ -1,5 +1,9 @@
 summary: Test rsyslog RELP transport with TLS encryption
-description: Verify that rsyslog reliably delivers messages between client and server using RELP with GnuTLS encryption, confirming all 500 test messages arrive without loss or duplication and that traffic is encrypted on the wire.
+description: |
+    Verify that rsyslog reliably delivers messages between client and server
+    using RELP with GnuTLS encryption, confirming all 500 test messages
+    arrive without loss or duplication and that traffic is encrypted on the
+    wire.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 require+:

--- a/Multihost/rsyslog-gssapi-log-delivery-sanity/main.fmf
+++ b/Multihost/rsyslog-gssapi-log-delivery-sanity/main.fmf
@@ -1,15 +1,26 @@
 summary: the test can be used for testing several scenarios of rsyslog gssapi communication
-description: "The test is testing gssapi communication between rsyslog client and\
-    \ server.\nCan be used for various scenarios. The set up can be configured using\
-    \ two\nglobal variables:\n\nCLIENT_SETUP - messages to be send by rsyslog client,\
-    \ can be \"gssapi\", \"plain\" (for tcp/plain)\n or \"both\" (default)\n\nSERVER_SETUP\
-    \ - messages accepted by rsyslog server, can be \"gssapi\" (only) or \"both\"\
-    \ (for gssapi and\n tcp/plain, uses InputGSSServerPermitPlainTCP on in rsyslog.conf)\n\
-    \nFor delivering tcp/plain messages both rsyslog client and netcat is used (to\
-    \ simulate two independent\nsources of logs)\n\nExamples:\nCLIENT_SETUP=gssapi\
-    \ SERVER_SETUP=gssapi - gssapi only communication, can be used \n to reproduce\
-    \ bug 867001\n\nCLIENT_SETUP=plain SERVER_SETUP=both - can be used to reproduce\
-    \ bug 862517\n\nRelated bugs: 867001, 862517, 867016\n\n"
+description: |
+    The test is testing gssapi communication between rsyslog client and
+    server. Can be used for various scenarios. The set up can be configured
+    using two global variables:
+
+    CLIENT_SETUP - messages to be send by rsyslog client, can be "gssapi",
+    "plain" (for tcp/plain) or "both" (default)
+
+    SERVER_SETUP - messages accepted by rsyslog server, can be "gssapi"
+    (only) or "both" (for gssapi and tcp/plain, uses
+    InputGSSServerPermitPlainTCP on in rsyslog.conf)
+
+    For delivering tcp/plain messages both rsyslog client and netcat is used
+    (to simulate two independent sources of logs)
+
+    Examples: CLIENT_SETUP=gssapi SERVER_SETUP=gssapi - gssapi only
+    communication, can be used to reproduce bug 867001
+
+    CLIENT_SETUP=plain SERVER_SETUP=both - can be used to reproduce bug
+    862517
+
+    Related bugs: 867001, 862517, 867016
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 component:
 - rsyslog

--- a/Multihost/rsyslog-send-messages-to-remote/main.fmf
+++ b/Multihost/rsyslog-send-messages-to-remote/main.fmf
@@ -1,5 +1,9 @@
 summary: Check that rsyslog send messages to remote if in forked debug mode
-description: Verify that rsyslog correctly sends messages to a remote server in all startup modes (normal, debug, non-forked normal, and non-forked debug), confirming that all 1000 test messages are delivered without loss or duplication in each mode.
+description: |
+    Verify that rsyslog correctly sends messages to a remote server in all
+    startup modes (normal, debug, non-forked normal, and non-forked debug),
+    confirming that all 1000 test messages are delivered without loss or
+    duplication in each mode.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 component:
   - rsyslog7

--- a/Multihost/rsyslog-send-messages-to-remote/main.fmf
+++ b/Multihost/rsyslog-send-messages-to-remote/main.fmf
@@ -1,5 +1,5 @@
 summary: Check that rsyslog send messages to remote if in forked debug mode
-description: ''
+description: Verify that rsyslog correctly sends messages to a remote server in all startup modes (normal, debug, non-forked normal, and non-forked debug), confirming that all 1000 test messages are delivered without loss or duplication in each mode.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 component:
   - rsyslog7

--- a/Regression/RHEL-54663-ossl-gnutlsPriorityString/main.fmf
+++ b/Regression/RHEL-54663-ossl-gnutlsPriorityString/main.fmf
@@ -1,4 +1,5 @@
-description: Test for RHEL-54663 custom ciphers using gnutlsPriorityString 
+description: |
+    Test for RHEL-54663 custom ciphers using gnutlsPriorityString option
     option
 contact: Attila Lakatos <alakatos@redhat.com>
 test: ./runtest.sh

--- a/Regression/bz1866877-parsing-msg/main.fmf
+++ b/Regression/bz1866877-parsing-msg/main.fmf
@@ -1,4 +1,5 @@
 summary: Test for BZ#1866877 pasring msg's PRIORITY
+description: Verify that rsyslog does not produce "unexpected length" errors when parsing message priority fields, specifically after running ansible-playbook operations that may generate unusual log entries.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 duration: 10m

--- a/Regression/bz1866877-parsing-msg/main.fmf
+++ b/Regression/bz1866877-parsing-msg/main.fmf
@@ -1,5 +1,8 @@
 summary: Test for BZ#1866877 pasring msg's PRIORITY
-description: Verify that rsyslog does not produce "unexpected length" errors when parsing message priority fields, specifically after running ansible-playbook operations that may generate unusual log entries.
+description: |
+    Verify that rsyslog does not produce "unexpected length" errors when
+    parsing message priority fields, specifically after running ansible-
+    playbook operations that may generate unusual log entries.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 duration: 10m

--- a/Regression/bz1880434-gnutls-shutdown/main.fmf
+++ b/Regression/bz1880434-gnutls-shutdown/main.fmf
@@ -1,5 +1,8 @@
 summary: gnutls shutdown
-description: Verify that rsyslog shuts down cleanly within a reasonable time when using GnuTLS TLS-encrypted TCP forwarding and the remote port is blocked by iptables, ensuring the service is not killed due to a timeout.
+description: |
+    Verify that rsyslog shuts down cleanly within a reasonable time when
+    using GnuTLS TLS-encrypted TCP forwarding and the remote port is blocked
+    by iptables, ensuring the service is not killed due to a timeout.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 require+:

--- a/Regression/bz1880434-gnutls-shutdown/main.fmf
+++ b/Regression/bz1880434-gnutls-shutdown/main.fmf
@@ -1,4 +1,5 @@
 summary: gnutls shutdown
+description: Verify that rsyslog shuts down cleanly within a reasonable time when using GnuTLS TLS-encrypted TCP forwarding and the remote port is blocked by iptables, ensuring the service is not killed due to a timeout.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 require+:

--- a/Regression/bz1886400-gnutls-shutdown-relp/main.fmf
+++ b/Regression/bz1886400-gnutls-shutdown-relp/main.fmf
@@ -1,5 +1,8 @@
 summary: relp gnutls shutdown
-description: Verify that rsyslog shuts down cleanly within a reasonable time when using RELP with GnuTLS TLS encryption and the remote port is blocked by iptables, ensuring the service is not killed due to a timeout.
+description: |
+    Verify that rsyslog shuts down cleanly within a reasonable time when
+    using RELP with GnuTLS TLS encryption and the remote port is blocked by
+    iptables, ensuring the service is not killed due to a timeout.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 require+:

--- a/Regression/bz1886400-gnutls-shutdown-relp/main.fmf
+++ b/Regression/bz1886400-gnutls-shutdown-relp/main.fmf
@@ -1,4 +1,5 @@
 summary: relp gnutls shutdown
+description: Verify that rsyslog shuts down cleanly within a reasonable time when using RELP with GnuTLS TLS encryption and the remote port is blocked by iptables, ensuring the service is not killed due to a timeout.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 require+:

--- a/Regression/bz1909639-imfile-leaves-state-files-behind/main.fmf
+++ b/Regression/bz1909639-imfile-leaves-state-files-behind/main.fmf
@@ -1,4 +1,5 @@
-description: Test for BZ#1909639 imfile leaves state files behind
+description: |
+    Test for BZ#1909639 imfile leaves state files behind
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 duration: 10m

--- a/Regression/bz1944718-large-group/main.fmf
+++ b/Regression/bz1944718-large-group/main.fmf
@@ -1,6 +1,10 @@
 summary: Test for BZ#1944718 rsyslog fails to execute actions due to having a
     too large group
-description: Verify that rsyslog correctly resolves group IDs and writes log files with proper ownership when the target group contains a large number of members (200 users), without producing "ID for group could not be found" errors.
+description: |
+    Verify that rsyslog correctly resolves group IDs and writes log files
+    with proper ownership when the target group contains a large number of
+    members (200 users), without producing "ID for group could not be found"
+    errors.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 duration: 10m

--- a/Regression/bz1944718-large-group/main.fmf
+++ b/Regression/bz1944718-large-group/main.fmf
@@ -1,5 +1,6 @@
-summary: Test for BZ#1944718 rsyslog fails to execute actions due to having a 
+summary: Test for BZ#1944718 rsyslog fails to execute actions due to having a
     too large group
+description: Verify that rsyslog correctly resolves group IDs and writes log files with proper ownership when the target group contains a large number of members (200 users), without producing "ID for group could not be found" errors.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 duration: 10m

--- a/Regression/bz1960536-imjournal-fsync-fd-leak/main.fmf
+++ b/Regression/bz1960536-imjournal-fsync-fd-leak/main.fmf
@@ -1,5 +1,9 @@
 summary: Test for BZ#1960536 rsyslog fd leak when Fsync="on" is set
-description: Verify that rsyslog does not leak file descriptors when the imjournal module is configured with FSync="on", by checking that the number of open file descriptors remains stable after processing multiple log messages.
+description: |
+    Verify that rsyslog does not leak file descriptors when the imjournal
+    module is configured with FSync="on", by checking that the number of
+    open file descriptors remains stable after processing multiple log
+    messages.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 duration: 10m

--- a/Regression/bz1960536-imjournal-fsync-fd-leak/main.fmf
+++ b/Regression/bz1960536-imjournal-fsync-fd-leak/main.fmf
@@ -1,4 +1,5 @@
 summary: Test for BZ#1960536 rsyslog fd leak when Fsync="on" is set
+description: Verify that rsyslog does not leak file descriptors when the imjournal module is configured with FSync="on", by checking that the number of open file descriptors remains stable after processing multiple log messages.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 duration: 10m

--- a/Regression/bz1962318-errfile-maxsize/main.fmf
+++ b/Regression/bz1962318-errfile-maxsize/main.fmf
@@ -1,4 +1,5 @@
 summary: errfile maxsize
+description: Verify that the action.errorfile.maxsize parameter correctly limits the error file size to the configured value, both when the error file is initially empty and when it already contains data.
 contact: Sergio Arroutbi <sarroutb@redhat.com>
 test: ./runtest.sh
 require+:

--- a/Regression/bz1962318-errfile-maxsize/main.fmf
+++ b/Regression/bz1962318-errfile-maxsize/main.fmf
@@ -1,5 +1,8 @@
 summary: errfile maxsize
-description: Verify that the action.errorfile.maxsize parameter correctly limits the error file size to the configured value, both when the error file is initially empty and when it already contains data.
+description: |
+    Verify that the action.errorfile.maxsize parameter correctly limits the
+    error file size to the configured value, both when the error file is
+    initially empty and when it already contains data.
 contact: Sergio Arroutbi <sarroutb@redhat.com>
 test: ./runtest.sh
 require+:

--- a/Regression/bz2052403-remove-wd-on-filemove/main.fmf
+++ b/Regression/bz2052403-remove-wd-on-filemove/main.fmf
@@ -1,4 +1,6 @@
-description: Test for BZ#2052403 imfile does not remove watch descriptor on 
+description: |
+    Test for BZ#2052403 imfile does not remove watch descriptor on inode
+    change
     inode change
 contact: Attila Lakatos <alakatos@redhat.com>
 test: ./runtest.sh

--- a/Regression/posixly-correct/main.fmf
+++ b/Regression/posixly-correct/main.fmf
@@ -1,4 +1,5 @@
-description: check that the logrotate script is posixly correct
+description: |
+    check that the logrotate script is posixly correct
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 duration: 5m

--- a/Sanity/basic-logging-facility/main.fmf
+++ b/Sanity/basic-logging-facility/main.fmf
@@ -1,4 +1,5 @@
-description: Tests basic logging facility
+description: |
+    Tests basic logging facility
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 path: /Sanity/basic-logging-facility

--- a/Sanity/bz1932795-rebase-to-2102/main.fmf
+++ b/Sanity/bz1932795-rebase-to-2102/main.fmf
@@ -1,5 +1,10 @@
 summary: Test for BZ#1932795 rsyslog rebase to 2102
-description: 'Verify that features introduced in the rsyslog 2102 rebase work correctly, including the exists() RainerScript function, backtick cat of non-existent files without segfault, omfwd stats counters and rate limiting, imptcp max sessions, imfile per-minute rate limiting, immark custom messages, and TLS certificate verify depth validation.'
+description: |
+    Verify that features introduced in the rsyslog 2102 rebase work
+    correctly, including the exists() RainerScript function, backtick cat of
+    non-existent files without segfault, omfwd stats counters and rate
+    limiting, imptcp max sessions, imfile per-minute rate limiting, immark
+    custom messages, and TLS certificate verify depth validation.
 contact: Attila Lakatos <alakatos@redhat.com>
 test: ./runtest.sh
 duration: 10m

--- a/Sanity/bz1932795-rebase-to-2102/main.fmf
+++ b/Sanity/bz1932795-rebase-to-2102/main.fmf
@@ -1,4 +1,5 @@
 summary: Test for BZ#1932795 rsyslog rebase to 2102
+description: 'Verify that features introduced in the rsyslog 2102 rebase work correctly, including the exists() RainerScript function, backtick cat of non-existent files without segfault, omfwd stats counters and rate limiting, imptcp max sessions, imfile per-minute rate limiting, immark custom messages, and TLS certificate verify depth validation.'
 contact: Attila Lakatos <alakatos@redhat.com>
 test: ./runtest.sh
 duration: 10m

--- a/Sanity/bz672182-RFE-Provide-multi-line-message-capability/main.fmf
+++ b/Sanity/bz672182-RFE-Provide-multi-line-message-capability/main.fmf
@@ -1,4 +1,5 @@
-description: Test for bz672182 ([RFE] Provide multi-line message capability)?
+description: |
+    Test for bz672182 ([RFE] Provide multi-line message capability)?
 link:
   - verifies: https://bugzilla.redhat.com/show_bug.cgi?id=672182
 contact: Dalibor Pospíšil <dapospis@redhat.com>

--- a/Sanity/capabilities-drop/main.fmf
+++ b/Sanity/capabilities-drop/main.fmf
@@ -1,5 +1,9 @@
 summary: tests dropping of capabilities
-description: Verify that rsyslog correctly drops Linux capabilities when configured with PrivDropToUser or PrivDropToGroup directives, retaining only the expected capability set for root and dropping all capabilities for non-root users.
+description: |
+    Verify that rsyslog correctly drops Linux capabilities when configured
+    with PrivDropToUser or PrivDropToGroup directives, retaining only the
+    expected capability set for root and dropping all capabilities for non-
+    root users.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 require+:

--- a/Sanity/capabilities-drop/main.fmf
+++ b/Sanity/capabilities-drop/main.fmf
@@ -1,4 +1,5 @@
 summary: tests dropping of capabilities
+description: Verify that rsyslog correctly drops Linux capabilities when configured with PrivDropToUser or PrivDropToGroup directives, retaining only the expected capability set for root and dropping all capabilities for non-root users.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 require+:

--- a/Sanity/command-source/main.fmf
+++ b/Sanity/command-source/main.fmf
@@ -1,4 +1,5 @@
-description: check that the logrotate script is posixly correct
+description: |
+    check that the logrotate script is posixly correct
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 duration: 5m

--- a/Sanity/config-enabled/main.fmf
+++ b/Sanity/config-enabled/main.fmf
@@ -1,5 +1,8 @@
 summary: Tests various configuration directives
-description: 'Verify that the config.enabled parameter correctly enables or disables rsyslog configuration objects including actions, global directives, inputs, modules, rulesets, parsers, timezones, and include files.'
+description: |
+    Verify that the config.enabled parameter correctly enables or disables
+    rsyslog configuration objects including actions, global directives,
+    inputs, modules, rulesets, parsers, timezones, and include files.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 require+:

--- a/Sanity/config-enabled/main.fmf
+++ b/Sanity/config-enabled/main.fmf
@@ -1,5 +1,5 @@
 summary: Tests various configuration directives
-description: ''
+description: 'Verify that the config.enabled parameter correctly enables or disables rsyslog configuration objects including actions, global directives, inputs, modules, rulesets, parsers, timezones, and include files.'
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 require+:

--- a/Sanity/elasticsearch-TLS/main.fmf
+++ b/Sanity/elasticsearch-TLS/main.fmf
@@ -1,5 +1,9 @@
 summary: Smoke test for elastic search feature with TLS communication
-description: Verify that rsyslog can forward log messages to an Elasticsearch instance over TLS using the omelasticsearch module, confirming that messages sent via logger are indexed and retrievable through the Elasticsearch HTTPS API.
+description: |
+    Verify that rsyslog can forward log messages to an Elasticsearch
+    instance over TLS using the omelasticsearch module, confirming that
+    messages sent via logger are indexed and retrievable through the
+    Elasticsearch HTTPS API.
 contact: Patrik Koncity <pkoncity@redhat.com>
 test: ./runtest.sh
 require+:

--- a/Sanity/elasticsearch-TLS/main.fmf
+++ b/Sanity/elasticsearch-TLS/main.fmf
@@ -1,5 +1,5 @@
 summary: Smoke test for elastic search feature with TLS communication
-description: ''
+description: Verify that rsyslog can forward log messages to an Elasticsearch instance over TLS using the omelasticsearch module, confirming that messages sent via logger are indexed and retrievable through the Elasticsearch HTTPS API.
 contact: Patrik Koncity <pkoncity@redhat.com>
 test: ./runtest.sh
 require+:

--- a/Sanity/gnutls-certificate-revocation/main.fmf
+++ b/Sanity/gnutls-certificate-revocation/main.fmf
@@ -1,5 +1,9 @@
 summary: Test for GnuTLS certificate revocation checking (stapled OCSP)
-description: Verify that rsyslog with GnuTLS correctly handles OCSP certificate revocation by accepting connections when the server certificate is valid and refusing connections when the server certificate has been revoked via stapled OCSP responses.
+description: |
+    Verify that rsyslog with GnuTLS correctly handles OCSP certificate
+    revocation by accepting connections when the server certificate is valid
+    and refusing connections when the server certificate has been revoked
+    via stapled OCSP responses.
 contact: Anderson Toshiyuki Sasaki <ansasaki@redhat.com>
 component:
   - rsyslog

--- a/Sanity/gnutls-certificate-revocation/main.fmf
+++ b/Sanity/gnutls-certificate-revocation/main.fmf
@@ -1,5 +1,5 @@
 summary: Test for GnuTLS certificate revocation checking (stapled OCSP)
-description: ''
+description: Verify that rsyslog with GnuTLS correctly handles OCSP certificate revocation by accepting connections when the server certificate is valid and refusing connections when the server certificate has been revoked via stapled OCSP responses.
 contact: Anderson Toshiyuki Sasaki <ansasaki@redhat.com>
 component:
   - rsyslog

--- a/Sanity/gnutls-openssl/main.fmf
+++ b/Sanity/gnutls-openssl/main.fmf
@@ -1,4 +1,5 @@
-description: a sanity test for TLS communication
+description: |
+    a sanity test for TLS communication
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 require+:

--- a/Sanity/imkafka-TLS-module-test/main.fmf
+++ b/Sanity/imkafka-TLS-module-test/main.fmf
@@ -1,5 +1,9 @@
 summary: sanity test for omkafka module and TLS usage
-description: Verify that the imkafka module can consume messages from a TLS-secured Kafka broker using mutual certificate authentication, confirming that messages produced to Kafka over SSL are successfully received and written to a log file by rsyslog.
+description: |
+    Verify that the imkafka module can consume messages from a TLS-secured
+    Kafka broker using mutual certificate authentication, confirming that
+    messages produced to Kafka over SSL are successfully received and
+    written to a log file by rsyslog.
 contact: Patrik Koncity <pkoncity@redhat.com>
 component:
   - rsyslog

--- a/Sanity/imkafka-TLS-module-test/main.fmf
+++ b/Sanity/imkafka-TLS-module-test/main.fmf
@@ -1,5 +1,5 @@
 summary: sanity test for omkafka module and TLS usage
-description: ''
+description: Verify that the imkafka module can consume messages from a TLS-secured Kafka broker using mutual certificate authentication, confirming that messages produced to Kafka over SSL are successfully received and written to a log file by rsyslog.
 contact: Patrik Koncity <pkoncity@redhat.com>
 component:
   - rsyslog

--- a/Sanity/imkafka-granular-metrics/main.fmf
+++ b/Sanity/imkafka-granular-metrics/main.fmf
@@ -1,5 +1,8 @@
 summary: Test imkafka module granular metrics via impstats
-description: Verify that the imkafka module exposes granular per-topic metrics through impstats, including submitted and received counters that correctly reflect the number of consumed Kafka messages.
+description: |
+    Verify that the imkafka module exposes granular per-topic metrics
+    through impstats, including submitted and received counters that
+    correctly reflect the number of consumed Kafka messages.
 contact: Adam Prikryl <aprikryl@redhat.com>
 component:
   - rsyslog

--- a/Sanity/imkafka-granular-metrics/main.fmf
+++ b/Sanity/imkafka-granular-metrics/main.fmf
@@ -1,4 +1,5 @@
 summary: Test imkafka module granular metrics via impstats
+description: Verify that the imkafka module exposes granular per-topic metrics through impstats, including submitted and received counters that correctly reflect the number of consumed Kafka messages.
 contact: Adam Prikryl <aprikryl@redhat.com>
 component:
   - rsyslog

--- a/Sanity/impstats-dropped-messages/main.fmf
+++ b/Sanity/impstats-dropped-messages/main.fmf
@@ -1,5 +1,9 @@
 summary: Tests dropped messages of impstats module
-description: Verify that the impstats module correctly reports the number of rate-limited discarded messages via the ratelimit.discarded counter when imuxsock rate limiting is active, and that only the allowed burst of messages is logged.
+description: |
+    Verify that the impstats module correctly reports the number of rate-
+    limited discarded messages via the ratelimit.discarded counter when
+    imuxsock rate limiting is active, and that only the allowed burst of
+    messages is logged.
 contact: Adam Prikryl <aprikryl@redhat.com>
 test: ./runtest.sh
 duration: 5m

--- a/Sanity/impstats-dropped-messages/main.fmf
+++ b/Sanity/impstats-dropped-messages/main.fmf
@@ -1,4 +1,5 @@
 summary: Tests dropped messages of impstats module
+description: Verify that the impstats module correctly reports the number of rate-limited discarded messages via the ratelimit.discarded counter when imuxsock rate limiting is active, and that only the allowed burst of messages is logged.
 contact: Adam Prikryl <aprikryl@redhat.com>
 test: ./runtest.sh
 duration: 5m

--- a/Sanity/impstats-zabbix-lld/main.fmf
+++ b/Sanity/impstats-zabbix-lld/main.fmf
@@ -1,4 +1,5 @@
 summary: Test impstats module Zabbix LLD output format
+description: Verify that the impstats module produces valid JSON output in Zabbix LLD format and does not emit legacy key=value format when configured with format="zabbix".
 contact: Adam Prikryl <aprikryl@redhat.com>
 test: ./runtest.sh
 duration: 10m

--- a/Sanity/impstats-zabbix-lld/main.fmf
+++ b/Sanity/impstats-zabbix-lld/main.fmf
@@ -1,5 +1,8 @@
 summary: Test impstats module Zabbix LLD output format
-description: Verify that the impstats module produces valid JSON output in Zabbix LLD format and does not emit legacy key=value format when configured with format="zabbix".
+description: |
+    Verify that the impstats module produces valid JSON output in Zabbix LLD
+    format and does not emit legacy key=value format when configured with
+    format="zabbix".
 contact: Adam Prikryl <aprikryl@redhat.com>
 test: ./runtest.sh
 duration: 10m

--- a/Sanity/imrelp-omrelp-module-test/main.fmf
+++ b/Sanity/imrelp-omrelp-module-test/main.fmf
@@ -1,5 +1,8 @@
 summary: Sanity test for imrelp and omrelp modules using openssl/gnutls tls libs
-description: Verify that imrelp and omrelp modules correctly transmit messages over TLS using all combinations of GnuTLS and OpenSSL drivers, and that the traffic is encrypted on the wire.
+description: |
+    Verify that imrelp and omrelp modules correctly transmit messages over
+    TLS using all combinations of GnuTLS and OpenSSL drivers, and that the
+    traffic is encrypted on the wire.
 contact: Attila Lakatos <alakatos@redhat.com>
 test: ./runtest.sh
 require+:

--- a/Sanity/imrelp-omrelp-module-test/main.fmf
+++ b/Sanity/imrelp-omrelp-module-test/main.fmf
@@ -1,4 +1,5 @@
 summary: Sanity test for imrelp and omrelp modules using openssl/gnutls tls libs
+description: Verify that imrelp and omrelp modules correctly transmit messages over TLS using all combinations of GnuTLS and OpenSSL drivers, and that the traffic is encrypted on the wire.
 contact: Attila Lakatos <alakatos@redhat.com>
 test: ./runtest.sh
 require+:

--- a/Sanity/mmfields-module-test/main.fmf
+++ b/Sanity/mmfields-module-test/main.fmf
@@ -1,4 +1,5 @@
 summary: tests basic mmfields module functionality
+description: Verify that the mmfields module correctly splits delimited input into JSON fields using default and custom separators, and supports the jsonRoot option for controlling output structure.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 require+:

--- a/Sanity/mmfields-module-test/main.fmf
+++ b/Sanity/mmfields-module-test/main.fmf
@@ -1,5 +1,8 @@
 summary: tests basic mmfields module functionality
-description: Verify that the mmfields module correctly splits delimited input into JSON fields using default and custom separators, and supports the jsonRoot option for controlling output structure.
+description: |
+    Verify that the mmfields module correctly splits delimited input into
+    JSON fields using default and custom separators, and supports the
+    jsonRoot option for controlling output structure.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 require+:

--- a/Sanity/mmkubernetes-module-test/main.fmf
+++ b/Sanity/mmkubernetes-module-test/main.fmf
@@ -1,5 +1,5 @@
 summary: basic sanity check for mmkubernetes module
-description: ''
+description: Verify that the mmkubernetes module enriches container log messages with Kubernetes metadata including namespace, pod, and container information by querying a mock API server.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 require+:

--- a/Sanity/mmkubernetes-module-test/main.fmf
+++ b/Sanity/mmkubernetes-module-test/main.fmf
@@ -1,5 +1,8 @@
 summary: basic sanity check for mmkubernetes module
-description: Verify that the mmkubernetes module enriches container log messages with Kubernetes metadata including namespace, pod, and container information by querying a mock API server.
+description: |
+    Verify that the mmkubernetes module enriches container log messages with
+    Kubernetes metadata including namespace, pod, and container information
+    by querying a mock API server.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 require+:

--- a/Sanity/mmnormalize-module-test/main.fmf
+++ b/Sanity/mmnormalize-module-test/main.fmf
@@ -1,4 +1,5 @@
 summary: tests basic mmfields module functionality
+description: Verify that the mmnormalize module correctly parses CEF-formatted log messages and extracts structured fields including device vendor, product, version, and extension key-value pairs.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 require+:

--- a/Sanity/mmnormalize-module-test/main.fmf
+++ b/Sanity/mmnormalize-module-test/main.fmf
@@ -1,5 +1,8 @@
 summary: tests basic mmfields module functionality
-description: Verify that the mmnormalize module correctly parses CEF-formatted log messages and extracts structured fields including device vendor, product, version, and extension key-value pairs.
+description: |
+    Verify that the mmnormalize module correctly parses CEF-formatted log
+    messages and extracts structured fields including device vendor,
+    product, version, and extension key-value pairs.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 require+:

--- a/Sanity/non-root-execution/main.fmf
+++ b/Sanity/non-root-execution/main.fmf
@@ -1,5 +1,8 @@
 summary: run rsyslog under a non-root user
-description: Verify that rsyslog can be started and can process log messages when running as a non-root user with a custom configuration, socket, and log directory.
+description: |
+    Verify that rsyslog can be started and can process log messages when
+    running as a non-root user with a custom configuration, socket, and log
+    directory.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 require+:

--- a/Sanity/non-root-execution/main.fmf
+++ b/Sanity/non-root-execution/main.fmf
@@ -1,4 +1,5 @@
 summary: run rsyslog under a non-root user
+description: Verify that rsyslog can be started and can process log messages when running as a non-root user with a custom configuration, socket, and log directory.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 require+:

--- a/Sanity/omkafka-TLS-module-test/main.fmf
+++ b/Sanity/omkafka-TLS-module-test/main.fmf
@@ -1,5 +1,8 @@
 summary: sanity test for omkafka module and TLS usage
-description: Verify that the omkafka module can send log messages to a Kafka broker over a TLS-encrypted connection using configurable cryptographic algorithms and that the messages are received by a TLS-enabled consumer.
+description: |
+    Verify that the omkafka module can send log messages to a Kafka broker
+    over a TLS-encrypted connection using configurable cryptographic
+    algorithms and that the messages are received by a TLS-enabled consumer.
 contact: Patrik Koncity <pkoncity@redhat.com>
 component:
   - rsyslog

--- a/Sanity/omkafka-TLS-module-test/main.fmf
+++ b/Sanity/omkafka-TLS-module-test/main.fmf
@@ -1,5 +1,5 @@
 summary: sanity test for omkafka module and TLS usage
-description: ''
+description: Verify that the omkafka module can send log messages to a Kafka broker over a TLS-encrypted connection using configurable cryptographic algorithms and that the messages are received by a TLS-enabled consumer.
 contact: Patrik Koncity <pkoncity@redhat.com>
 component:
   - rsyslog

--- a/Sanity/omprog/logging/main.fmf
+++ b/Sanity/omprog/logging/main.fmf
@@ -1,4 +1,5 @@
-description: basic omprog test
+description: |
+    basic omprog test
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 require+:

--- a/Sanity/omprog/signal_HUP/main.fmf
+++ b/Sanity/omprog/signal_HUP/main.fmf
@@ -1,4 +1,5 @@
-description: test omprog handluing of the HUP signal
+description: |
+    test omprog handluing of the HUP signal
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 require+:

--- a/Sanity/openssl-parameters/main.fmf
+++ b/Sanity/openssl-parameters/main.fmf
@@ -1,4 +1,5 @@
 summary: openssl connection parameters
+description: Verify that rsyslog OpenSSL TLS connection parameters such as tls.tlscfgcmd for protocol version restrictions work correctly on both client and server sides when using imrelp/omrelp, and that traffic is encrypted.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 require+:

--- a/Sanity/openssl-parameters/main.fmf
+++ b/Sanity/openssl-parameters/main.fmf
@@ -1,5 +1,9 @@
 summary: openssl connection parameters
-description: Verify that rsyslog OpenSSL TLS connection parameters such as tls.tlscfgcmd for protocol version restrictions work correctly on both client and server sides when using imrelp/omrelp, and that traffic is encrypted.
+description: |
+    Verify that rsyslog OpenSSL TLS connection parameters such as
+    tls.tlscfgcmd for protocol version restrictions work correctly on both
+    client and server sides when using imrelp/omrelp, and that traffic is
+    encrypted.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 require+:

--- a/Sanity/per-connection-ssl/main.fmf
+++ b/Sanity/per-connection-ssl/main.fmf
@@ -1,4 +1,5 @@
-description: Test various SSL connection configuration places
+description: |
+    Test various SSL connection configuration places
 contact: Dalibor Pospisil <dapospis@redhat.com>
 test: ./runtest.sh
 require+:

--- a/Sanity/pid-source/main.fmf
+++ b/Sanity/pid-source/main.fmf
@@ -1,4 +1,5 @@
-description: check that the logrotate script is posixly correct
+description: |
+    check that the logrotate script is posixly correct
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 duration: 5m

--- a/Sanity/rsyslog-files-ownership/main.fmf
+++ b/Sanity/rsyslog-files-ownership/main.fmf
@@ -1,5 +1,6 @@
 summary: verify correct file ownership
-description: verifies if important rsyslog files have correct ownership
+description: |
+    verifies if important rsyslog files have correct ownership
 contact: Adam Prikryl <aprikryl@redhat.com>
 component:
   - rsyslog

--- a/Sanity/test-various-configuration-directives/main.fmf
+++ b/Sanity/test-various-configuration-directives/main.fmf
@@ -1,7 +1,10 @@
 summary: Tests various configuration directives
-description: "The test tests various configuration directives \n(see http://www.rsyslog.com/doc-rsyslog_conf_global.html)\n\
-    \nAt the moment there are testcases for:\n$ActionExecOnlyOnceEveryInterval\n$ActionSendTCPRebindInterval\n\
-    \n"
+description: |
+    The test tests various configuration directives (see
+    http://www.rsyslog.com/doc-rsyslog_conf_global.html)
+
+    At the moment there are testcases for: $ActionExecOnlyOnceEveryInterval
+    $ActionSendTCPRebindInterval
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 path: /Sanity/test-various-configuration-directives

--- a/Sanity/unit-security-options/main.fmf
+++ b/Sanity/unit-security-options/main.fmf
@@ -1,4 +1,5 @@
-description: check systemd-analyze setting for rsyslog
+description: |
+    check systemd-analyze setting for rsyslog
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 require+:

--- a/Sanity/various-simple-checks/main.fmf
+++ b/Sanity/various-simple-checks/main.fmf
@@ -1,5 +1,5 @@
 summary: various-simple-checks
-description: ''
+description: Verify that rsyslog passes various basic sanity checks including correct PID file creation, absence of segfaults on restart, proper config validation return codes, and correct handling of the net.aclResolveHostname global option.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 require+:

--- a/Sanity/various-simple-checks/main.fmf
+++ b/Sanity/various-simple-checks/main.fmf
@@ -1,5 +1,9 @@
 summary: various-simple-checks
-description: Verify that rsyslog passes various basic sanity checks including correct PID file creation, absence of segfaults on restart, proper config validation return codes, and correct handling of the net.aclResolveHostname global option.
+description: |
+    Verify that rsyslog passes various basic sanity checks including correct
+    PID file creation, absence of segfaults on restart, proper config
+    validation return codes, and correct handling of the
+    net.aclResolveHostname global option.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 require+:


### PR DESCRIPTION
Add descriptions to test cases that had empty or missing description field in main.fmf.

## Summary by Sourcery

Add missing descriptive metadata to various test cases defined in main.fmf files.

Documentation:
- Add human-readable descriptions to multiple existing test cases in main.fmf to clarify their purpose.

Tests:
- Update metadata of numerous Multihost, Regression, and Sanity tests by filling in previously empty or missing description fields.