### PR TITLE
[MOKOSH] RHEL-151324 - Test for gtls driver with expired CRL

### DIFF
--- a/Regression/RHEL-151324-gtls-expired-crl/PURPOSE
+++ b/Regression/RHEL-151324-gtls-expired-crl/PURPOSE
@@ -1,0 +1,4 @@
+PURPOSE of /CoreOS/rsyslog/Regression/RHEL-151324-gtls-expired-crl
+Description: This test verifies that rsyslog, when configured with the GnuTLS (gtls) driver, correctly rejects incoming TLS connections if the specified Certificate Revocation List (CRL) file has expired.
+Author: QE Automation <sec-eng-special@redhat.com>
+Bug: https://issues.redhat.com/browse/RHEL-151324

--- a/Regression/RHEL-151324-gtls-expired-crl/main.fmf
+++ b/Regression/RHEL-151324-gtls-expired-crl/main.fmf
@@ -1,0 +1,28 @@
+summary: Test for RHEL-151324 - rsyslog with gtls driver accepts connections with expired CRL
+description: |
+    Bug: https://issues.redhat.com/browse/RHEL-151324
+    Verify that rsyslog using the GnuTLS driver correctly rejects
+    connections when the configured Certificate Revocation List (CRL)
+    file has expired.
+contact: QE Automation <sec-eng-special@redhat.com>
+test: ./runtest.sh
+framework: beakerlib
+recommend:
+    - rsyslog
+    - rsyslog-gnutls
+    - openssl
+    - policycoreutils-python-utils
+require:
+    - library(openssl/certgen)
+duration: 5m
+tag:
+    - NoRHEL4
+    - NoRHEL5
+    - NoRHEL6
+    - NoRHEL7
+    - NoRHEL8
+    - NoRHEL9
+adjust:
+    - enabled: false
+      when: distro < rhel-10.3
+      continue: false

--- a/Regression/RHEL-151324-gtls-expired-crl/runtest.sh
+++ b/Regression/RHEL-151324-gtls-expired-crl/runtest.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+rlJournalStart
+    rlPhaseStartSetup "Setup"
+        rlAssertRpm "rsyslog" "rsyslog-gnutls" "openssl"
+        rlRun "rlImport openssl/certgen"
+
+        # Stop rsyslog to apply new configuration
+        rlServiceStop rsyslog.service
+
+        # Backup original configuration
+        rlFileBackup "/etc/rsyslog.conf"
+        rlFileBackup --clean "/etc/rsyslog.d"
+
+        # Create a temporary directory for certificates
+        rlRun "TmpDir=\$(mktemp -d)" 0 "Create tmp directory"
+        rlRun "pushd \$TmpDir"
+
+        # Generate CA, server, and client certificates
+        rlRun "x509KeyGen ca"
+        rlRun "x509KeyGen server"
+        rlRun "x509KeyGen client"
+        rlRun "x509SelfSign ca"
+        rlRun "x509CertSign --CA ca server"
+        rlRun "x509CertSign --CA ca client"
+
+        # Create a Certificate Revocation List (CRL)
+        rlRun "openssl ca -gencrl -config ca/ca.cnf -out crl.pem -keyfile ca/key.pem -cert ca/cert.pem" "Generate initial CRL"
+
+        # Copy certificates to rsyslog.d
+        rlRun "cp \$(x509Cert ca) /etc/rsyslog.d/ca.pem"
+        rlRun "cp \$(x509Cert server) /etc/rsyslog.d/server-cert.pem"
+        rlRun "cp \$(x509Key server) /etc/rsyslog.d/server-key.pem"
+        rlRun "cp crl.pem /etc/rsyslog.d/crl.pem"
+
+        # Configure rsyslog server (imtcp with gtls)
+        cat > /etc/rsyslog.d/imtcp.conf <<EOF
+module(load="imtcp")
+input(type="imtcp" port="6514"
+      streamdriver.name="gtls"
+      streamdriver.mode="1"
+      streamdriver.authmode="x509/certvalid"
+      defaultnetstreamdrivercafile="/etc/rsyslog.d/ca.pem"
+      defaultnetstreamdrivercrlfile="/etc/rsyslog.d/crl.pem"
+      defaultnetstreamdrivercertfile="/etc/rsyslog.d/server-cert.pem"
+      defaultnetstreamdriverkeyfile="/etc/rsyslog.d/server-key.pem"
+)
+EOF
+        # Configure rsyslog client (omfwd with gtls)
+        cat > /etc/rsyslog.conf <<EOF
+global(defaultNetstreamDriver="gtls"
+       defaultNetstreamDriverCAFile="/etc/rsyslog.d/ca.pem"
+       defaultNetstreamDriverCertFile="\$(x509Cert client)"
+       defaultNetstreamDriverKeyFile="\$(x509Key client)")
+
+action(type="omfwd" protocol="tcp" target="127.0.0.1" port="6514"
+       streamDriver="gtls" streamDriverMode="1"
+       streamDriverAuthMode="x509/name"
+       streamDriverPermittedPeers="localhost")
+
+# For debugging
+global(debug.logFile="/var/log/rsyslog-debug.log"
+       debug.gnutls="1")
+EOF
+        rlRun "cat /etc/rsyslog.d/imtcp.conf"
+        rlRun "cat /etc/rsyslog.conf"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Test with valid CRL"
+        # Ensure CRL is valid (just generated)
+        rlRun "openssl crl -in /etc/rsyslog.d/crl.pem -noout -nextupdate"
+        rlServiceStart rsyslog.service
+        rlAssertGrep "rsyslogd was started" "/var/log/messages" -E
+        # Send a test message
+        rlRun "logger 'Message with valid CRL'"
+        sleep 2
+        # Check if the message was received
+        rlAssertGrep "Message with valid CRL" "/var/log/messages"
+        rlServiceStop rsyslog.service
+    rlPhaseEnd
+
+    rlPhaseStartTest "Test with expired CRL"
+        # Create an expired CRL by setting the 'days' option to a negative value
+        rlRun "openssl ca -gencrl -config ca/ca.cnf -out /etc/rsyslog.d/crl.pem -keyfile ca/key.pem -cert ca/cert.pem -days -1" "Generate expired CRL"
+        rlRun "openssl crl -in /etc/rsyslog.d/crl.pem -noout -nextupdate"
+        rlAssertGrep "nextUpdate" "$(rlRun 'openssl crl -in /etc/rsyslog.d/crl.pem -noout -nextupdate')"
+        
+        # Start rsyslog and expect it to fail to accept connections
+        rlServiceStart rsyslog.service
+        # The service should start, but not accept connections
+        rlAssertGrep "rsyslogd was started" "/var/log/messages" -E
+
+        # Try to send a message, it should fail
+        rlRun "logger 'Message with expired CRL'"
+        sleep 2
+        # The message should NOT be in the log
+        rlAssertNotGrep "Message with expired CRL" "/var/log/messages"
+        # Check debug log for connection rejection
+        rlAssertGrep "CRL in 'crl.pem' has expired" "/var/log/rsyslog-debug.log"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup "Cleanup"
+        rlServiceStop rsyslog.service
+        rlFileRestore
+        rlRun "popd"
+        rlRun "rm -rf \$TmpDir"
+        rlServiceRestore rsyslog.service
+    rlPhaseEnd
+rlJournalEnd


### PR DESCRIPTION
This PR was generated by the QE automation pipeline to address the testing requirements for RHEL-151324.

h3. Test Summary
This test verifies that rsyslog, when configured with the GnuTLS (gtls) driver, correctly rejects incoming TLS connections if the specified Certificate Revocation List (CRL) file has expired.

h3. How to Run
The test can be run using TMT:
`tmt run -avv plans --name /plans/some_plan tests --name /Regression/RHEL-151324-gtls-expired-crl`

h3. Reference Tests
The following existing test was used as a reference for framework, metadata, and structure:
* `/CoreOS/rsyslog/Sanity/gnutls-certificate-revocation`

This PR requires human review.

## Summary by Sourcery

Add a new regression test verifying rsyslog gtls behavior when using an expired CRL.

New Features:
- Introduce a beakerlib-based test that configures rsyslog with gtls and validates message delivery with a valid CRL versus rejection with an expired CRL.

Tests:
- Add a new TMT/beakerlib regression test for RHEL-151324 to ensure rsyslog correctly rejects TLS connections when the configured CRL has expired.